### PR TITLE
Skip redundant steps in CSV sync

### DIFF
--- a/sync_csv.sh
+++ b/sync_csv.sh
@@ -76,7 +76,7 @@ if [[ $mobile == 1 ]]; then
   rtable="${rtable}_mobile"
 fi
 
-bq show httparchive:runs.${ptable} &> /dev/null
+bq show httparchive:${ptable} &> /dev/null
 if [ $? -ne 0 ]; then
   echo -e "Submitting new pages import ${ptable} to BigQuery"
   bq --nosync load $ptable gs://httparchive/${archive}/pages.csv.gz $BASE/schema/pages.json
@@ -84,10 +84,10 @@ else
   echo -e "${ptable} already exists, skipping."
 fi
 
-bq show httparchive:runs.${rtable} &> /dev/null
+bq show httparchive:${rtable} &> /dev/null
 if [ $? -ne 0 ]; then
   echo -e "Submitting new requests import ${rtable} to BigQuery"
-  bq --nosync load $rtable gs://httparchive/${archive}/requests_* $BASE/schema/requests.json
+  bq load $rtable gs://httparchive/${archive}/requests_* $BASE/schema/requests.json
 else
   echo -e "${rtable} already exists, skipping."
 fi

--- a/sync_csv.sh
+++ b/sync_csv.sh
@@ -21,21 +21,27 @@ fi
 
 mkdir -p $DATA/processed/$archive
 
-echo -e "Downloading data for $archive"
 cd $DATA
 
-wget -nv -N "http://httparchive.org/downloads/httparchive_${archive}_pages.csv.gz"
-#wget -nv -N "http://www.archive.org/download/httparchive_downloads_${adate}/httparchive_${archive}_pages.csv.gz"
-if [ $? -ne 0 ]; then
-  echo "Pages data for ${adate} is missing, exiting"
-  exit
+if [ ! -f httparchive_${archive}_pages.csv.gz ]; then
+  echo -e "Downloading data for $archive"
+  wget -nv -N "http://httparchive.org/downloads/httparchive_${archive}_pages.csv.gz"
+  if [ $? -ne 0 ]; then
+    echo "Pages data for ${adate} is missing, exiting"
+    exit
+  fi
+else
+  echo -e "Pages data already downloaded for $archive, skipping."
 fi
 
-wget -nv -N "http://httparchive.org/downloads/httparchive_${archive}_requests.csv.gz"
-#wget -nv -N "http://www.archive.org/download/httparchive_downloads_${adate}/httparchive_${archive}_requests.csv.gz"
-if [ $? -ne 0 ]; then
-  echo "Request data for ${adate} is missing, exiting"
-  exit
+if [ ! -f httparchive_${archive}_requests.csv.gz ]; then
+  wget -nv -N "http://httparchive.org/downloads/httparchive_${archive}_requests.csv.gz"
+  if [ $? -ne 0 ]; then
+    echo "Request data for ${adate} is missing, exiting"
+    exit
+  fi
+else
+  echo -e "Request data already downloaded for $archive, skipping."
 fi
 
 if [ ! -f processed/${archive}/pages.csv.gz ]; then
@@ -68,26 +74,23 @@ gsutil cp -n * gs://httparchive/${archive}/
 if [[ $mobile == 1 ]]; then
   ptable="${ptable}_mobile"
   rtable="${rtable}_mobile"
-  #nosync="--nosync"
-  nosync=""
-else
-  nosync=""
 fi
 
-echo -e "Submitting new pages import ${ptable} to BigQuery"
-bq --nosync load $ptable gs://httparchive/${archive}/pages.csv.gz $BASE/schema/pages.json
+bq show httparchive:runs.${ptable} &> /dev/null
+if [ $? -ne 0 ]; then
+  echo -e "Submitting new pages import ${ptable} to BigQuery"
+  bq --nosync load $ptable gs://httparchive/${archive}/pages.csv.gz $BASE/schema/pages.json
+else
+  echo -e "${ptable} already exists, skipping."
+fi
 
-first=1
-for f in `ls -r requests_*`; do
-  if [[ $first == 1 ]]; then
-    echo "Submitting new requests import ${rtable} to BigQuery: $f"
-    bq $nosync load $rtable gs://httparchive/${archive}/$f $BASE/schema/requests.json
-    first=0
-  else
-    echo "Submitting append requests import ${rtable} to BigQuery: $f"
-    bq --nosync load $rtable gs://httparchive/${archive}/$f
-  fi
-done
+bq show httparchive:runs.${rtable} &> /dev/null
+if [ $? -ne 0 ]; then
+  echo -e "Submitting new requests import ${rtable} to BigQuery"
+  bq --nosync load $rtable gs://httparchive/${archive}/requests_* $BASE/schema/requests.json
+else
+  echo -e "${rtable} already exists, skipping."
+fi
 
 cd $BASE
 echo "Done"


### PR DESCRIPTION
Adds conditional logic around the following:

- downloading pages from HA
- downloading requests from HA
- exporting pages from GS to BQ
- exporting requests from GS to BQ

The upload to GS is not gated with an if statement because the command includes a "no clobber" flag that skips uploading files that already exist.

Also cleaned up unused `--nosync` logic for the requests table.

Output from running the script on a completed crawl:

```
. sync_csv.sh May_15_2017
Processing May_15_2017, mobile: 0, archive: May_15_2017
Pages data already downloaded for May_15_2017, skipping.
Request data already downloaded for May_15_2017, skipping.
Pages data already converted, skipping.
Request data already converted, skipping.
Syncing data to Google Storage
Skipping existing item: gs://httparchive/May_15_2017/pages.csv.gz
Skipping existing item: gs://httparchive/May_15_2017/requests_aa.gz
Skipping existing item: gs://httparchive/May_15_2017/requests_ab.gz
Skipping existing item: gs://httparchive/May_15_2017/requests_ac.gz

==> NOTE: You are performing a sequence of gsutil operations that may
run significantly faster if you instead use gsutil -m -o ... Please
see the -m section under "gsutil help options" for further information
about when gsutil -m can be advantageous.

Skipping existing item: gs://httparchive/May_15_2017/requests_ad.gz
Skipping existing item: gs://httparchive/May_15_2017/requests_ae.gz
Skipping existing item: gs://httparchive/May_15_2017/requests_af.gz
Skipping existing item: gs://httparchive/May_15_2017/requests_ag.gz
runs.2017_05_15_pages already exists, skipping.
runs.2017_05_15_requests already exists, skipping.
Done
```
So nothing was actually affected. :+1: 