### PR TITLE
Add lighthouse field to _pages tables

### DIFF
--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -138,6 +138,7 @@ public class BigQueryImport {
                 JsonNode har = c.element();
                 JsonNode data = har.get("log");
                 JsonNode pages = data.get("pages");
+                JsonNode lighthouse = har.get("_lighthouse");
 
                 if (pages.size() == 0) {
                     LOG.error("Empty HAR, skipping: {}", MAPPER.writeValueAsString(har));
@@ -156,9 +157,13 @@ public class BigQueryImport {
                 ObjectNode object = (ObjectNode) page;
                 String pageJSON = MAPPER.writeValueAsString(object);
 
+                object = (ObjectNode) lighthouse;
+                String lighthouseJSON = MAPPER.writeValueAsString(object);
+
                 TableRow pageRow = new TableRow()
                         .set("url", pageUrl)
-                        .set("payload", pageJSON);
+                        .set("payload", pageJSON)
+                        .set("lighthouse", lighthouseJSON);
                 c.output(pageRow);
 
                 JsonNode entries = data.get("entries");
@@ -308,6 +313,8 @@ public class BigQueryImport {
                 .setDescription("URL of the parent document"));
         page.add(new TableFieldSchema().setName("payload").setType("STRING")
                 .setDescription("JSON-encoded parent document HAR data"));
+        page.add(new TableFieldSchema().setName("lighthouse").setType("STRING")
+                .setDescription("JSON-encoded Lighthouse results"));
         TableSchema pageSchema = new TableSchema().setFields(page);
 
         PCollection<TableRow> pages = results.get(BigQueryImport.PAGES_TAG);


### PR DESCRIPTION
Updates the `har.YYYY_MM_DD_[android,chrome]_pages` table schema and parses out the `_lighthouse` property from the HAR file.

To test the changes, I took the sample HAR from https://github.com/HTTPArchive/httparchive/issues/87#issuecomment-292543543 and collapsed all whitespace. Turns out the HarJsonCoder doesn't like newlines. Then I gzipped and uploaded to `gs://httparchive/test-Jun_14_2017` along with a `done` file. Here's the command I used to run the pipeline:

```
mvn compile exec:java -Dexec.mainClass=com.httparchive.dataflow.BigQueryImport -Dexec.args="--project=httparchive --stagingLocation=gs://httparchive/dataflow/staging --runner=BlockingDataflowPipelineRunner --input=test-Jun_14_2017 --workerMachineType=n1-standard-4"
```

This generated a new (temporary) table in BQ: https://bigquery.cloud.google.com/table/httparchive:har.2017_06_14_test_pages?tab=schema

Example query:
```
SELECT
  url,
  JSON_EXTRACT(lighthouse, '$.audits[\'script-blocking-first-paint\'].displayValue') AS scriptBlockingFirstPaint,
  JSON_EXTRACT(lighthouse, '$.audits[\'script-blocking-first-paint\'].extendedInfo.value.results[0].url') AS scriptBlockingFirstPaintUrl
FROM
  [httparchive:har.2017_06_14_test_pages]
```
![image](https://user-images.githubusercontent.com/1120896/27148873-d4af17fc-510f-11e7-84a0-6ddde6230055.png)

I also ran an older HAR file through the pipeline that didn't have the LH property. This simulates how desktop crawls will be processed, because LH is not yet enabled for them. See https://bigquery.cloud.google.com/table/httparchive:har.2017_04_25_test_pages?tab=schema . The `lighthouse` fields are null.

The temp tables are just for demoing and will be deleted shortly.