### PR TITLE
Fix sync_har table

### DIFF
--- a/sync_har.sh
+++ b/sync_har.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd $HOME/code/dataflow
+cd $HOME/code/dataflow/java
 BASE=`pwd`
 
 if [ -n "$2" ]; then

--- a/sync_har.sh
+++ b/sync_har.sh
@@ -15,8 +15,10 @@ fi
 
 if [ $day -ge 15 ]; then
   import_date=$(date +"${month}_15_${year}")
+  table="${year}_${month}_15"
 else
   import_date=$(date +"${month}_1_${year}")
+  table="${year}_${month}_01"
 fi
 
 if [ -n "$1" ]; then
@@ -24,9 +26,11 @@ if [ -n "$1" ]; then
   if [[ $1 == *chrome* ]]; then
     mobile=0
     bucket="chrome-${import_date}"
+    table="${table}_chrome"
   else
     mobile=1
     bucket="android-${import_date}"
+    table="${table}_android"
   fi
   echo "Processing $bucket, mobile: $mobile"
 
@@ -36,8 +40,6 @@ else
   exit
 fi
 
-table=${bucket,,}
-table=${table/-/_}
 if bq show "httparchive:har.${table}_pages"; then
   echo "Table already exists in BigQuery, exiting"
   exit 1


### PR DESCRIPTION
In the logs:

> BigQuery error in show operation: Not found: Table
> httparchive:har.chrome_jun_15_2017_pages

`chrome_jun_15_2017_pages` is not the format for the HAR tables. Should be eg `2017_06_15_chrome_pages`.

Fixing this should allow the script to exit early if the table already exists.

Also fixes changing to the `/dataflow/java` dir.