### PR TITLE
Lighthouse support in HAR Dataflow

### DIFF
--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -138,6 +138,7 @@ public class BigQueryImport {
                 JsonNode har = c.element();
                 JsonNode data = har.get("log");
                 JsonNode pages = data.get("pages");
+                JsonNode lighthouse = har.get("_lighthouse");
 
                 if (pages.size() == 0) {
                     LOG.error("Empty HAR, skipping: {}", MAPPER.writeValueAsString(har));
@@ -156,9 +157,13 @@ public class BigQueryImport {
                 ObjectNode object = (ObjectNode) page;
                 String pageJSON = MAPPER.writeValueAsString(object);
 
+                object = (ObjectNode) lighthouse;
+                String lighthouseJSON = MAPPER.writeValueAsString(object);
+
                 TableRow pageRow = new TableRow()
                         .set("url", pageUrl)
-                        .set("payload", pageJSON);
+                        .set("payload", pageJSON)
+                        .set("lighthouse", lighthouseJSON);
                 c.output(pageRow);
 
                 JsonNode entries = data.get("entries");
@@ -308,6 +313,8 @@ public class BigQueryImport {
                 .setDescription("URL of the parent document"));
         page.add(new TableFieldSchema().setName("payload").setType("STRING")
                 .setDescription("JSON-encoded parent document HAR data"));
+        page.add(new TableFieldSchema().setName("lighthouse").setType("STRING")
+                .setDescription("JSON-encoded Lighthouse results"));
         TableSchema pageSchema = new TableSchema().setFields(page);
 
         PCollection<TableRow> pages = results.get(BigQueryImport.PAGES_TAG);

--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -79,8 +79,8 @@ public class BigQueryImport {
         private final Aggregator<Long, Long> skippedBody
                 = createAggregator("skippedBody", new Sum.SumLongFn());
 
-        // truncate content at ~9.9MB; row limit is 10MB.
-        private static final Integer MAX_CONTENT_SIZE = 10 * 1024 * 1024;
+        // truncate content at ~1.9MB; row limit is 2MB.
+        private static final Integer MAX_CONTENT_SIZE = 2 * 1024 * 1024;
 
         public static Response truncateUTF8(String s, int maxBytes) {
             int b = 0;
@@ -162,22 +162,19 @@ public class BigQueryImport {
 
                 object = (ObjectNode) lighthouse;
                 String lighthouseJSON = MAPPER.writeValueAsString(object);
-                Boolean skipLH = lighthouseJSON.getBytes("UTF-8").length >=
-                        MAX_CONTENT_SIZE - pageJSON.getBytes("UTF-8").length;
-                
-                if (skipLH) {
-                    LOG.error("Lighthouse too large, skipping: {} {} {}",
-                            pageUrl, pageJSON, lighthouseJSON);
-                    skippedLighthouse.addValue(1L);
-                    lighthouseJSON = null;
-                }
 
                 TableRow pageRow = new TableRow()
                         .set("url", pageUrl)
                         .set("payload", pageJSON)
-                        .set("lighthouse", lighthouseJSON)
-                        .set("skipLH", skipLH);
-                c.output(pageRow);
+                        .set("lighthouse", lighthouseJSON);
+
+                String pageRowJSON = MAPPER.writeValueAsString(pageRow);
+                Integer pageRowSize = pageRowJSON.getBytes("UTF-8").length;
+                if (pageRowSize > MAX_CONTENT_SIZE) {
+                    skippedLighthouse.addValue(1L);
+                } else {
+                    c.output(pageRow);
+                }
 
                 JsonNode entries = data.get("entries");
                 for (final JsonNode r : entries) {
@@ -328,8 +325,6 @@ public class BigQueryImport {
                 .setDescription("JSON-encoded parent document HAR data"));
         page.add(new TableFieldSchema().setName("lighthouse").setType("STRING")
                 .setDescription("JSON-encoded Lighthouse results"));
-        page.add(new TableFieldSchema().setName("skipLH").setType("BOOLEAN")
-                .setDescription("Flag is true if Lighthouse report exceeds size limit"));
         TableSchema pageSchema = new TableSchema().setFields(page);
 
         PCollection<TableRow> pages = results.get(BigQueryImport.PAGES_TAG);
@@ -365,7 +360,7 @@ public class BigQueryImport {
         body.add(new TableFieldSchema().setName("body").setType("STRING")
                 .setDescription("Body of the response"));
         body.add(new TableFieldSchema().setName("truncated").setType("BOOLEAN")
-                .setDescription("Flag is true if body is >10MB"));
+                .setDescription("Flag is true if body is >2MB"));
         TableSchema bodySchema = new TableSchema().setFields(body);
 
         PCollection<TableRow> bodies = results.get(BigQueryImport.BODIES_TAG);


### PR DESCRIPTION
Skip row if too big for BQ. This may be too aggressive and we may want to consider truncating the JSON data (making it invalid?) or dropping the LH data entirely.

Marking @igrigorik as a reviewer but merging now to get it in for the 6/15 crawl. I'll resolve any comments and rerun the pipeline as needed.