### PR TITLE
Write Lighthouse reports to a new *_lighthouse table

### DIFF
--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -138,6 +138,7 @@ public class BigQueryImport {
                 JsonNode har = c.element();
                 JsonNode data = har.get("log");
                 JsonNode pages = data.get("pages");
+                JsonNode lighthouse = har.get("_lighthouse");
 
                 if (pages.size() == 0) {
                     LOG.error("Empty HAR, skipping: {}", MAPPER.writeValueAsString(har));
@@ -156,9 +157,13 @@ public class BigQueryImport {
                 ObjectNode object = (ObjectNode) page;
                 String pageJSON = MAPPER.writeValueAsString(object);
 
+                object = (ObjectNode) lighthouse;
+                String lighthouseJSON = MAPPER.writeValueAsString(object);
+
                 TableRow pageRow = new TableRow()
                         .set("url", pageUrl)
-                        .set("payload", pageJSON);
+                        .set("payload", pageJSON)
+                        .set("lighthouse", lighthouseJSON);
                 c.output(pageRow);
 
                 JsonNode entries = data.get("entries");
@@ -308,6 +313,8 @@ public class BigQueryImport {
                 .setDescription("URL of the parent document"));
         page.add(new TableFieldSchema().setName("payload").setType("STRING")
                 .setDescription("JSON-encoded parent document HAR data"));
+        page.add(new TableFieldSchema().setName("lighthouse").setType("STRING")
+                .setDescription("JSON-encoded Lighthouse results"));
         TableSchema pageSchema = new TableSchema().setFields(page);
 
         PCollection<TableRow> pages = results.get(BigQueryImport.PAGES_TAG);

--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -79,8 +79,8 @@ public class BigQueryImport {
         private final Aggregator<Long, Long> skippedBody
                 = createAggregator("skippedBody", new Sum.SumLongFn());
 
-        // truncate content at ~9.9MB; row limit is 10MB.
-        private static final Integer MAX_CONTENT_SIZE = 10 * 1024 * 1024;
+        // truncate content at ~1.9MB; row limit is 2MB.
+        private static final Integer MAX_CONTENT_SIZE = 2 * 1024 * 1024;
 
         public static Response truncateUTF8(String s, int maxBytes) {
             int b = 0;
@@ -162,22 +162,19 @@ public class BigQueryImport {
 
                 object = (ObjectNode) lighthouse;
                 String lighthouseJSON = MAPPER.writeValueAsString(object);
-                Boolean skipLH = lighthouseJSON.getBytes("UTF-8").length >=
-                        MAX_CONTENT_SIZE - pageJSON.getBytes("UTF-8").length;
-                
-                if (skipLH) {
-                    LOG.error("Lighthouse too large, skipping: {} {} {}",
-                            pageUrl, pageJSON, lighthouseJSON);
-                    skippedLighthouse.addValue(1L);
-                    lighthouseJSON = null;
-                }
 
                 TableRow pageRow = new TableRow()
                         .set("url", pageUrl)
                         .set("payload", pageJSON)
-                        .set("lighthouse", lighthouseJSON)
-                        .set("skipLH", skipLH);
-                c.output(pageRow);
+                        .set("lighthouse", lighthouseJSON);
+
+                String pageRowJSON = MAPPER.writeValueAsString(pageRow);
+                Integer pageRowSize = pageRowJSON.getBytes("UTF-8").length;
+                if (pageRowSize > MAX_CONTENT_SIZE) {
+                    skippedLighthouse.addValue(1L);
+                } else {
+                    c.output(pageRow);
+                }
 
                 JsonNode entries = data.get("entries");
                 for (final JsonNode r : entries) {
@@ -328,8 +325,6 @@ public class BigQueryImport {
                 .setDescription("JSON-encoded parent document HAR data"));
         page.add(new TableFieldSchema().setName("lighthouse").setType("STRING")
                 .setDescription("JSON-encoded Lighthouse results"));
-        page.add(new TableFieldSchema().setName("skipLH").setType("BOOLEAN")
-                .setDescription("Flag is true if Lighthouse report exceeds size limit"));
         TableSchema pageSchema = new TableSchema().setFields(page);
 
         PCollection<TableRow> pages = results.get(BigQueryImport.PAGES_TAG);
@@ -365,7 +360,7 @@ public class BigQueryImport {
         body.add(new TableFieldSchema().setName("body").setType("STRING")
                 .setDescription("Body of the response"));
         body.add(new TableFieldSchema().setName("truncated").setType("BOOLEAN")
-                .setDescription("Flag is true if body is >10MB"));
+                .setDescription("Flag is true if body is >2MB"));
         TableSchema bodySchema = new TableSchema().setFields(body);
 
         PCollection<TableRow> bodies = results.get(BigQueryImport.BODIES_TAG);

--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -160,6 +160,14 @@ public class BigQueryImport {
                 ObjectNode object = (ObjectNode) page;
                 String pageJSON = MAPPER.writeValueAsString(object);
 
+                // `audits` is redundant and can be omitted.
+                if (lighthouse != null) {
+                    for (JsonNode category : lighthouse.get("reportCategories")) {
+                        object = (ObjectNode) category;
+                        object.remove("audits");
+                    }
+                }
+
                 object = (ObjectNode) lighthouse;
                 String lighthouseJSON = MAPPER.writeValueAsString(object);
 

--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -191,7 +191,7 @@ public class BigQueryImport {
                         .set("report", lighthouseJSON);
 
                 String lighthouseRowJSON = MAPPER.writeValueAsString(lighthouseRow);
-                Integer lighthouseRowSize = lighthouseRowJSON.getBytes("UTF-8").length;
+                Integer lighthouseRowSize = lighthouseRowJSON.getBytes("UTF-8").length + pageUrl.getBytes("UTF-8").length;
                 if (lighthouseRowSize > MAX_CONTENT_SIZE) {
                     skippedLighthouse.addValue(1L);
                 } else {


### PR DESCRIPTION
To summarize the latest changes in this PR:

- LH reports are no longer written to the *_pages table
- reportCategories..audits are omitted
- screenshot-thumbnails items (base64 encoded images) are omitted
- report is `NULL` rather than the string `"null"` when applicable

These are efforts to minimize the row size of the LH report so that we can fit more reports. Here are the number of skipped rows per optimization:

- none: ~12k
- omit audits: ~4.8k
- ^ + omit images: ~4.6k
- ^ + separate table: ~4.6k