### PR TITLE
redirect BQ output to datasubsets

### DIFF
--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -358,12 +358,11 @@ public class BigQueryImport {
                 .resolve("*.har.gz");
     }
 
-    // <project>:<dataset>.<table>
     // Input: chrome-Nov_15_2014
-    // Output: httparchive:har.2014_11_15_chrome_(trailer)
-    private static String getBigQueryOutput(Options options, String trailer) {
+    // Output: httparchive:dataset.YYYY_MM_DD_client
+    private static String getBigQueryOutput(Options options, String dataset) {
         String[] parts = options.getInput().split("-");
-        String type = parts[0];
+        String client = parts[0] == "chrome" ? "desktop" : "mobile";
         String date = parts[1];
 
         SimpleDateFormat inputFormatter = new SimpleDateFormat("MMM_dd_yyyy");
@@ -376,10 +375,9 @@ public class BigQueryImport {
             LOG.error("Failed to parse table date", e);
         }
 
-        return options.getOutput() + "." // har.
+        return dataset + "." // pages/requests/...
                 + date + "_" // 2014_11_15_
-                + type + "_" // chrome_
-                + trailer; // pages/requests/...
+                + client; // desktop/mobile
     }
 
     public static void main(String[] args) {
@@ -463,7 +461,7 @@ public class BigQueryImport {
         PCollection<TableRow> bodies = results.get(BigQueryImport.BODIES_TAG);
         bodies.apply(BigQueryIO.Write
                 .named("write-bodies")
-                .to(getBigQueryOutput(options, "requests_bodies"))
+                .to(getBigQueryOutput(options, "response_bodies"))
                 .withSchema(bodySchema)
                 .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
                 .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE));

--- a/sync_csv.sh
+++ b/sync_csv.sh
@@ -65,8 +65,8 @@ fi
 cd processed/${archive}
 
 table=$(date --date="$(echo $adate | sed "s/_/ /g" -)" "+%Y_%m_%d")
-ptable="runs.${table}_pages"
-rtable="runs.${table}_requests"
+ptable="summary_pages.${table}"
+rtable="summary_requests.${table}"
 
 echo -e "Syncing data to Google Storage"
 gsutil cp -n * gs://httparchive/${archive}/
@@ -74,6 +74,9 @@ gsutil cp -n * gs://httparchive/${archive}/
 if [[ $mobile == 1 ]]; then
   ptable="${ptable}_mobile"
   rtable="${rtable}_mobile"
+else
+  ptable="${ptable}_desktop"
+  rtable="${rtable}_desktop"
 fi
 
 bq show httparchive:${ptable} &> /dev/null

--- a/sync_har.sh
+++ b/sync_har.sh
@@ -26,15 +26,13 @@ fi
 if [ -n "$1" ]; then
   archive=$1
   if [[ $1 == *chrome* ]]; then
-    mobile=0
+    client="desktop"
     bucket="chrome-${import_date}"
-    table="${table}_chrome"
   else
-    mobile=1
+    client="mobile"
     bucket="android-${import_date}"
-    table="${table}_android"
   fi
-  echo "Processing $bucket, mobile: $mobile"
+  echo "Processing $bucket, client: $client"
 
 else
   echo "Must provide import type (e.g. chrome), and optional date:"
@@ -42,7 +40,7 @@ else
   exit
 fi
 
-if bq show "httparchive:har.${table}_pages"; then
+if bq show "httparchive:pages.${table}_${client}"; then
   echo "Table already exists in BigQuery, exiting"
   exit 1
 else


### PR DESCRIPTION
For context, see [doc](https://docs.google.com/document/d/1Ilm9B9Wje81OT5owYhtuxOWaKRcLv3UPtPnq3myCNbc/edit?usp=sharing).

Instead of writing to the har dataset, write to:
 - pages
 - requests
 - response_bodies
 - lighthouse

runs:
 - summary_pages
 - summary_requests

All tables will have a consistent client suffix of either `desktop` or `mobile`.

Progress on https://github.com/HTTPArchive/beta.httparchive.org/issues/13 "Report automation".