### PR TITLE
write wappalyzer detections to dedicated `technologies` table

### DIFF
--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -542,7 +542,7 @@ public class BigQueryImport {
         PCollection<TableRow> apps = results.get(BigQueryImport.APPS_TAG);
         apps.apply(BigQueryIO.Write
                 .named("write-apps")
-                .to(getBigQueryOutput(options, "apps"))
+                .to(getBigQueryOutput(options, "technologies"))
                 .withSchema(appSchema)
                 .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
                 .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE));


### PR DESCRIPTION
Create new YYYY_MM_DD_client tables under a new `apps` dataset. The schema for these tables is:

- `url` of the page
- `category` of the app
- `app` name
- `info` about the app, such as version string (optional)

Successfully processed the 4/1 desktop apps: https://bigquery.cloud.google.com/table/httparchive:apps.2018_04_01_desktop?tab=preview

Progress on #19 and https://github.com/HTTPArchive/httparchive.org/issues/40

cc @pmeenan