### PR TITLE
changed resp_age and resp_content_length from string to integers

### DIFF
--- a/schema/requests.json
+++ b/schema/requests.json
@@ -141,7 +141,7 @@
   },
   {
     "name": "resp_age",
-    "type": "STRING"
+    "type": "INTEGER"
   },
   {
     "name": "resp_cache_control",
@@ -161,7 +161,7 @@
   },
   {
     "name": "resp_content_length",
-    "type": "STRING"
+    "type": "INTEGER"
   },
   {
     "name": "resp_content_location",


### PR DESCRIPTION
In running a query this morning, I noticed that the resp_content_length is saved as a string - which I have to convert before doing math....  It also makes sorting in order funny.  So I changed to type integer.

In my quick hunt, I also saw that res_age was also a string, but served as an integer.

