### PR TITLE
updated LHR schema

### DIFF
--- a/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
+++ b/dataflow/java/src/main/java/com/httparchive/dataflow/BigQueryImport.java
@@ -266,11 +266,6 @@ public class BigQueryImport {
 
 
                 if (lighthouse != null && lighthouse.isObject()) {
-                    // `audits` is redundant and can be omitted.
-                    for (JsonNode category : lighthouse.get("reportCategories")) {
-                        object = (ObjectNode) category;
-                        object.remove("audits");
-                    }
                     // Omit image data.
                     object = (ObjectNode) lighthouse.get("audits").get("screenshot-thumbnails");
                     if (object != null) {


### PR DESCRIPTION
The JSON Lighthouse report (LHR) was updated recently and the grouping of report categories has changed. It is no longer `reportCategories` and it no longer duplicates the entire audit metadata, so this part can be removed from the pipeline.

It was causing the 2018_07_01_mobile dataflow jobs to fail with null pointer exceptions.