### PR TITLE
Lens fixes

### DIFF
--- a/config/storage-cors.json
+++ b/config/storage-cors.json
@@ -14,7 +14,8 @@
 				"http://httparchive.appspot.com",
 				"https://httparchive.appspot.com",
 				"http://httparchive-staging.appspot.com",
-				"https://httparchive-staging.appspot.com"
+				"https://httparchive-staging.appspot.com",
+				"https://wordpress.httparchive.org"
 			],
 			"responseHeader": ["Content-Type"],
 			"method": ["GET", "HEAD"],

--- a/sql/generate_report.sh
+++ b/sql/generate_report.sh
@@ -78,7 +78,7 @@ echo -e "Generating $metric $report_format"
 
 # Replace the date template in the query.
 # Run the query on BigQuery.
-result=$(sed -e "s/\(\`[^\`]*\`\)/\1 $lens_join/" $query \
+result=$(sed -e "s/\(\`[^\`]*\`)\?\)/\1 $lens_join/" $query \
 	| sed -e "s/\${YYYY_MM_DD}/$YYYY_MM_DD/g" \
 	| sed  -e "s/\${YYYYMM}/$YYYYMM/g" \
 	| $BQ_CMD)

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -99,7 +99,7 @@ else
 		# Run the query on BigQuery.
 		if [[ $LENS != "" ]]; then
 			lens_join="JOIN ($(cat sql/lens/$LENS/histograms.sql | tr '\n' ' ')) USING (url, _TABLE_SUFFIX)"
-			result=$(sed -e "s/\(\`[^\`]*\`\)/\1 $lens_join/" $query \
+			result=$(sed -e "s/\(\`[^\`]*\`)\?\)/\1 $lens_join/" $query \
 				| sed -e "s/\${YYYY_MM_DD}/$YYYY_MM_DD/g" \
 				| sed  -e "s/\${YYYYMM}/$YYYYMM/g" \
 				| $BQ_CMD)
@@ -142,7 +142,7 @@ else
 		# Run the query on BigQuery.
 		if [[ $LENS != "" ]]; then
 			lens_join="JOIN ($(cat sql/lens/$LENS/timeseries.sql | tr '\n' ' ')) USING (url, _TABLE_SUFFIX)"
-			result=$(sed -e "s/\(\`[^\`]*\`\)/\1 $lens_join/" $query \
+			result=$(sed -e "s/\(\`[^\`]*\`)\?\)/\1 $lens_join/" $query \
 				| $BQ_CMD)
 		else
 			result=$(cat $query \

--- a/sql/timeseries/h2.sql
+++ b/sql/timeseries/h2.sql
@@ -5,7 +5,7 @@ SELECT
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
   ROUND(SUM(IF(JSON_EXTRACT_SCALAR(payload, '$._protocol') = 'HTTP/2', 1, 0)) * 100 / COUNT(0), 2) AS percent
 FROM
-  `httparchive.requests.*`
+  (SELECT page AS url, payload, _TABLE_SUFFIX AS _TABLE_SUFFIX FROM `httparchive.requests.*`)
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/pctHttps.sql
+++ b/sql/timeseries/pctHttps.sql
@@ -3,9 +3,9 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(STARTS_WITH(url, 'https'), 1, 0)) * 100 / COUNT(0), 2) AS percent
+  ROUND(SUM(IF(STARTS_WITH(request, 'https'), 1, 0)) * 100 / COUNT(0), 2) AS percent
 FROM
-  `httparchive.summary_requests.*`
+  (SELECT url AS request, page AS url, _TABLE_SUFFIX AS _TABLE_SUFFIX FROM `httparchive.requests.*`)
 GROUP BY
   date,
   timestamp,


### PR DESCRIPTION
- ensure lens subdomain is whitelisted for CORS
- fix lens query `sed` replacement command to account for parens around the table name, eg for subqueries
- use subqueries for metrics that depend on the `requests` dataset
  - so that the subquery can alias the fields to be more easily joinable with the `technologies` dataset