### PR TITLE
Use materialized CrUX timeseries

### DIFF
--- a/sql/timeseries/cruxFastDcl.sql
+++ b/sql/timeseries/cruxFastDcl.sql
@@ -1,12 +1,11 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(form_factor.name = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(dcl.start < 1000, dcl.density, 0)) * 100 / SUM(dcl.density), 2) AS percent
+  REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(fast_dcl) * 100 / (SUM(fast_dcl) + SUM(avg_dcl) + SUM(slow_dcl)), 2) AS percent
 FROM
-  `chrome-ux-report.all.*`,
-  UNNEST(dom_content_loaded.histogram.bin) AS dcl
+  `chrome-ux-report.materialized.device_summary`
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxFastFcp.sql
+++ b/sql/timeseries/cruxFastFcp.sql
@@ -1,12 +1,11 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(form_factor.name = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(fcp.start < 1000, fcp.density, 0)) * 100 / SUM(fcp.density), 2) AS percent
+  REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(fast_fcp) * 100 / (SUM(fast_fcp) + SUM(avg_fcp) + SUM(slow_fcp)), 2) AS percent
 FROM
-  `chrome-ux-report.all.*`,
-  UNNEST(first_contentful_paint.histogram.bin) AS fcp
+  `chrome-ux-report.materialized.device_summary`
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxFastFid.sql
+++ b/sql/timeseries/cruxFastFid.sql
@@ -1,12 +1,11 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(form_factor.name = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(fid.start < 100, fid.density, 0)) * 100 / SUM(fid.density), 2) AS percent
+  REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(fast_fid) * 100 / (SUM(fast_fid) + SUM(avg_fid) + SUM(slow_fid)), 2) AS percent
 FROM
-  `chrome-ux-report.all.*`,
-  UNNEST(experimental.first_input_delay.histogram.bin) AS fid
+  `chrome-ux-report.materialized.device_summary`
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxFastFp.sql
+++ b/sql/timeseries/cruxFastFp.sql
@@ -1,12 +1,11 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(form_factor.name = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(fp.start < 1000, fp.density, 0)) * 100 / SUM(fp.density), 2) AS percent
+  REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(fast_fp) * 100 / (SUM(fast_fp) + SUM(avg_fp) + SUM(slow_fp)), 2) AS percent
 FROM
-  `chrome-ux-report.all.*`,
-  UNNEST(first_paint.histogram.bin) AS fp
+  `chrome-ux-report.materialized.device_summary`
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxFastOl.sql
+++ b/sql/timeseries/cruxFastOl.sql
@@ -1,12 +1,11 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(form_factor.name = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(ol.start < 1000, ol.density, 0)) * 100 / SUM(ol.density), 2) AS percent
+  REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(fast_ol) * 100 / (SUM(fast_ol) + SUM(avg_ol) + SUM(slow_ol)), 2) AS percent
 FROM
-  `chrome-ux-report.all.*`,
-  UNNEST(onload.histogram.bin) AS ol
+  `chrome-ux-report.materialized.device_summary`
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxSlowFcp.sql
+++ b/sql/timeseries/cruxSlowFcp.sql
@@ -1,12 +1,11 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(form_factor.name = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(fcp.start >= 2500, fcp.density, 0)) * 100 / SUM(fcp.density), 2) AS percent
+  REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(slow_fcp) * 100 / (SUM(fast_fcp) + SUM(avg_fcp) + SUM(slow_fcp)), 2) AS percent
 FROM
-  `chrome-ux-report.all.*`,
-  UNNEST(first_contentful_paint.histogram.bin) AS fcp
+  `chrome-ux-report.materialized.device_summary`
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxSlowFid.sql
+++ b/sql/timeseries/cruxSlowFid.sql
@@ -1,12 +1,11 @@
 #standardSQL
 SELECT
-  REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
-  UNIX_DATE(CAST(REGEXP_REPLACE(_TABLE_SUFFIX, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(form_factor.name = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(fid.start >= 250, fid.density, 0)) * 100 / SUM(fid.density), 2) AS percent
+  REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymm, '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(slow_fid) * 100 / (SUM(fast_fid) + SUM(avg_fid) + SUM(slow_fid)), 2) AS percent
 FROM
-  `chrome-ux-report.all.*`,
-  UNNEST(experimental.first_input_delay.histogram.bin) AS fid
+  `chrome-ux-report.materialized.device_summary`
 GROUP BY
   date,
   timestamp,


### PR DESCRIPTION
The materialized queries cost about 1% of their raw data equivalents.

This also fixes some inconsistencies in the fast/avg/slow calculations. For example, DCL used 1 second as the fast/avg threshold, when the accepted threshold is 1.5 seconds.