### PR TITLE
Avoid regenerating existing reports

### DIFF
--- a/sync_csv.sh
+++ b/sync_csv.sh
@@ -107,8 +107,13 @@ fi
 
 echo -e "Attempting to generate reports..."
 cd $HOME/code
-. sql/generate_reports.sh -fth $table
-ls -1 sql/lens | xargs -I lens sql/generate_reports.sh -fth $table -l lens
+
+gsutil -q stat gs://httparchive/reports/$table/*
+if [ $? -eq 0 ]; then
+  . sql/generate_reports.sh -fth $table
+  ls -1 sql/lens | xargs -I lens sql/generate_reports.sh -fth $table -l lens
+else
+  echo -e "Reports for ${table} already exist, skipping."
+fi
 
 echo "Done"
-

--- a/sync_csv.sh
+++ b/sync_csv.sh
@@ -109,7 +109,7 @@ echo -e "Attempting to generate reports..."
 cd $HOME/code
 
 gsutil -q stat gs://httparchive/reports/$table/*
-if [ $? -eq 0 ]; then
+if [ $? -eq 1 ]; then
   . sql/generate_reports.sh -fth $table
   ls -1 sql/lens | xargs -I lens sql/generate_reports.sh -fth $table -l lens
 else

--- a/sync_har.sh
+++ b/sync_har.sh
@@ -67,9 +67,15 @@ mvn compile exec:java -Dexec.mainClass=com.httparchive.dataflow.BigQueryImport \
                --workerMachineType=n1-highmem-4"
 
 
-echo "Attempting to generate reports..."
+echo -e "Attempting to generate reports..."
 cd $HOME/code
-. sql/generate_reports.sh -fth $table
-ls -1 sql/lens | xargs -I lens sql/generate_reports.sh -fth $table -l lens
+
+gsutil -q stat gs://httparchive/reports/$table/*
+if [ $? -eq 0 ]; then
+  . sql/generate_reports.sh -fth $table
+  ls -1 sql/lens | xargs -I lens sql/generate_reports.sh -fth $table -l lens
+else
+  echo -e "Reports for ${table} already exist, skipping."
+fi
 
 echo "Done"

--- a/sync_har.sh
+++ b/sync_har.sh
@@ -71,7 +71,7 @@ echo -e "Attempting to generate reports..."
 cd $HOME/code
 
 gsutil -q stat gs://httparchive/reports/$table/*
-if [ $? -eq 0 ]; then
+if [ $? -eq 1 ]; then
   . sql/generate_reports.sh -fth $table
   ls -1 sql/lens | xargs -I lens sql/generate_reports.sh -fth $table -l lens
 else


### PR DESCRIPTION
This should curb duplicate BQ analysis costs

```
Attempting to generate reports...
Reports for 2019_06_01 already exist, skipping.
Done
```