### PR TITLE
Add Project Fugu report 

### DIFF
--- a/sql/generate_report.sh
+++ b/sql/generate_report.sh
@@ -64,8 +64,7 @@ if [[ $LENS != "" ]]; then
 fi
 
 gs_url=gs://httparchive/reports/$gs_lens_dir$DESTINATION
-# query="sql/$report_format/$metric.sql"
-query="sql/timeseries/$metric.sql"
+query="sql/$report_format/$metric.sql"
 
 # Check to see if the results exist.
 gsutil ls $gs_url &> /dev/null

--- a/sql/generate_report.sh
+++ b/sql/generate_report.sh
@@ -35,7 +35,8 @@ done
 # Exit early if there's nothing to do.
 if [ $DESTINATION == 0 ]; then
 	echo -e "You must provide a destination with the -d flag." >&2
-	echo -e "For example: sql/generateReport.sh -d \"2018_01_15/bytesJs.json\"" >&2
+	echo -e "For example (histograms): sql/generateReport.sh -d \"2018_01_15/bytesJs.json\"" >&2
+	echo -e "            (timeseries): sql/generateReport.sh -d \"swControlledPages.json\"" >&2
 	exit 1
 fi
 
@@ -63,7 +64,8 @@ if [[ $LENS != "" ]]; then
 fi
 
 gs_url=gs://httparchive/reports/$gs_lens_dir$DESTINATION
-query="sql/$report_format/$metric.sql"
+# query="sql/$report_format/$metric.sql"
+query="sql/timeseries/$metric.sql"
 
 # Check to see if the results exist.
 gsutil ls $gs_url &> /dev/null

--- a/sql/timeseries/asyncClipboardRead.sql
+++ b/sql/timeseries/asyncClipboardRead.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/asyncClipboardRead.sql
+++ b/sql/timeseries/asyncClipboardRead.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.AsyncClipboardAPIRead'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2369'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/asyncClipboardRead.sql
+++ b/sql/timeseries/asyncClipboardRead.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.AsyncClipboardAPIRead'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2369'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2369"
+  OR feature = "AsyncClipboardAPIRead"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/asyncClipboardWrite.sql
+++ b/sql/timeseries/asyncClipboardWrite.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.AsyncClipboardAPIWrite'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2370'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/asyncClipboardWrite.sql
+++ b/sql/timeseries/asyncClipboardWrite.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.AsyncClipboardAPIWrite'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2370'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2370"
+  OR feature = "AsyncClipboardAPIWrite"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/asyncClipboardWrite.sql
+++ b/sql/timeseries/asyncClipboardWrite.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/badgeClear.sql
+++ b/sql/timeseries/badgeClear.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.BadgeClear'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2727'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2727"
+  OR feature = "BadgeClear"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/badgeClear.sql
+++ b/sql/timeseries/badgeClear.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/badgeClear.sql
+++ b/sql/timeseries/badgeClear.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.BadgeClear'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2727'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/badgeSet.sql
+++ b/sql/timeseries/badgeSet.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/badgeSet.sql
+++ b/sql/timeseries/badgeSet.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.BadgeSet'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2726'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2726"
+  OR feature = "BadgeSet"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/badgeSet.sql
+++ b/sql/timeseries/badgeSet.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.BadgeSet'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2726'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/contactPicker.sql
+++ b/sql/timeseries/contactPicker.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ContactsManagerSelect'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2993'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/contactPicker.sql
+++ b/sql/timeseries/contactPicker.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/contactPicker.sql
+++ b/sql/timeseries/contactPicker.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ContactsManagerSelect'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2993'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2993"
+  OR feature = "ContactsManagerSelect"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/contentIndex.sql
+++ b/sql/timeseries/contentIndex.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/contentIndex.sql
+++ b/sql/timeseries/contentIndex.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ContentIndexAdd'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2983'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2983"
+  OR feature = "ContentIndexAdd"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/contentIndex.sql
+++ b/sql/timeseries/contentIndex.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ContentIndexAdd'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2983'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/getInstalledRelatedApps.sql
+++ b/sql/timeseries/getInstalledRelatedApps.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/getInstalledRelatedApps.sql
+++ b/sql/timeseries/getInstalledRelatedApps.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.V8Navigator_GetInstalledRelatedApps_Method'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1870'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1870"
+  OR feature = "V8Navigator_GetInstalledRelatedApps_Method"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/getInstalledRelatedApps.sql
+++ b/sql/timeseries/getInstalledRelatedApps.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.V8Navigator_GetInstalledRelatedApps_Method'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1870'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/idleDetection.sql
+++ b/sql/timeseries/idleDetection.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/idleDetection.sql
+++ b/sql/timeseries/idleDetection.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.IdleDetectionStart'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2834'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/idleDetection.sql
+++ b/sql/timeseries/idleDetection.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.IdleDetectionStart'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2834'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2834"
+  OR feature = "IdleDetectionStart"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/nativeFileSystem.sql
+++ b/sql/timeseries/nativeFileSystem.sql
@@ -4,13 +4,14 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE
   id = "3015"
   OR feature = "V8Window_ChooseFileSystemEntries_Method"
+  OR id = "3339"
+  OR feature = "FileSystemPickerMethod"
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/nativeFileSystem.sql
+++ b/sql/timeseries/nativeFileSystem.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.V8Window_ChooseFileSystemEntries_Method'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3015'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "3015"
+  OR feature = "V8Window_ChooseFileSystemEntries_Method"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/nativeFileSystem.sql
+++ b/sql/timeseries/nativeFileSystem.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.V8Window_ChooseFileSystemEntries_Method'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3015'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/notificationTriggers.sql
+++ b/sql/timeseries/notificationTriggers.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.NotificationShowTrigger'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3017'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/notificationTriggers.sql
+++ b/sql/timeseries/notificationTriggers.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/notificationTriggers.sql
+++ b/sql/timeseries/notificationTriggers.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.NotificationShowTrigger'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3017'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "3017"
+  OR feature = "NotificationShowTrigger"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/periodicBackgroundSync.sql
+++ b/sql/timeseries/periodicBackgroundSync.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.PeriodicBackgroundSync'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2930'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/periodicBackgroundSync.sql
+++ b/sql/timeseries/periodicBackgroundSync.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/periodicBackgroundSync.sql
+++ b/sql/timeseries/periodicBackgroundSync.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.PeriodicBackgroundSync'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2930'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2930"
+  OR feature = "PeriodicBackgroundSync"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/periodicBackgroundSyncRegister.sql
+++ b/sql/timeseries/periodicBackgroundSyncRegister.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.PeriodicBackgroundSyncRegister'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2931'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2931"
+  OR feature = "PeriodicBackgroundSyncRegister"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/periodicBackgroundSyncRegister.sql
+++ b/sql/timeseries/periodicBackgroundSyncRegister.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/periodicBackgroundSyncRegister.sql
+++ b/sql/timeseries/periodicBackgroundSyncRegister.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.PeriodicBackgroundSyncRegister'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2931'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/quicTransport.sql
+++ b/sql/timeseries/quicTransport.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.QuicTransport'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3184'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "3184"
+  OR feature = "QuicTransport"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/quicTransport.sql
+++ b/sql/timeseries/quicTransport.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/quicTransport.sql
+++ b/sql/timeseries/quicTransport.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.QuicTransport'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3184'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/screenWakeLock.sql
+++ b/sql/timeseries/screenWakeLock.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/screenWakeLock.sql
+++ b/sql/timeseries/screenWakeLock.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WakeLockAcquireScreenLock'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3005'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/screenWakeLock.sql
+++ b/sql/timeseries/screenWakeLock.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WakeLockAcquireScreenLock'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3005'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "3005"
+  OR feature = "WakeLockAcquireScreenLock"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/shapeDetectionBarcode.sql
+++ b/sql/timeseries/shapeDetectionBarcode.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ShapeDetection_BarcodeDetectorConstructor'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1991'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/shapeDetectionBarcode.sql
+++ b/sql/timeseries/shapeDetectionBarcode.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/shapeDetectionBarcode.sql
+++ b/sql/timeseries/shapeDetectionBarcode.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ShapeDetection_BarcodeDetectorConstructor'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1991'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1991"
+  OR feature = "ShapeDetection_BarcodeDetectorConstructor"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/shapeDetectionFace.sql
+++ b/sql/timeseries/shapeDetectionFace.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ShapeDetection_FaceDetectorConstructor'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1992'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/shapeDetectionFace.sql
+++ b/sql/timeseries/shapeDetectionFace.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/shapeDetectionFace.sql
+++ b/sql/timeseries/shapeDetectionFace.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ShapeDetection_FaceDetectorConstructor'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1992'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1992"
+  OR feature = "ShapeDetection_FaceDetectorConstructor"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/shapeDetectionText.sql
+++ b/sql/timeseries/shapeDetectionText.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ShapeDetection_TextDetectorConstructor'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1993'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/shapeDetectionText.sql
+++ b/sql/timeseries/shapeDetectionText.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/shapeDetectionText.sql
+++ b/sql/timeseries/shapeDetectionText.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ShapeDetection_TextDetectorConstructor'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1993'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1993"
+  OR feature = "ShapeDetection_TextDetectorConstructor"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/storageEstimate.sql
+++ b/sql/timeseries/storageEstimate.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.DurableStorageEstimate'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1371'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1371"
+  OR feature = "DurableStorageEstimate"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/storageEstimate.sql
+++ b/sql/timeseries/storageEstimate.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/storageEstimate.sql
+++ b/sql/timeseries/storageEstimate.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.DurableStorageEstimate'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1371'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/storagePersist.sql
+++ b/sql/timeseries/storagePersist.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/storagePersist.sql
+++ b/sql/timeseries/storagePersist.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.DurableStoragePersist'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1369'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1369"
+  OR feature = "DurableStoragePersist"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/storagePersist.sql
+++ b/sql/timeseries/storagePersist.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.DurableStoragePersist'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1369'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/textFragment.sql
+++ b/sql/timeseries/textFragment.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.TextFragmentAnchorMatchFound'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2902'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/textFragment.sql
+++ b/sql/timeseries/textFragment.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.TextFragmentAnchorMatchFound'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2902'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2902"
+  OR feature = "TextFragmentAnchorMatchFound"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/textFragment.sql
+++ b/sql/timeseries/textFragment.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webBluetooth.sql
+++ b/sql/timeseries/webBluetooth.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webBluetooth.sql
+++ b/sql/timeseries/webBluetooth.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebBluetoothRequestDevice'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1670'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webBluetooth.sql
+++ b/sql/timeseries/webBluetooth.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebBluetoothRequestDevice'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1670'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1670"
+  OR feature = "WebBluetoothRequestDevice"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webMIDI.sql
+++ b/sql/timeseries/webMIDI.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.MIDIPortOpen'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2029'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webMIDI.sql
+++ b/sql/timeseries/webMIDI.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webMIDI.sql
+++ b/sql/timeseries/webMIDI.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.MIDIPortOpen'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2029'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2029"
+  OR feature = "MIDIPortOpen"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webNFCRead.sql
+++ b/sql/timeseries/webNFCRead.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webNFCRead.sql
+++ b/sql/timeseries/webNFCRead.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebNfcNdefReaderScan'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3094'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "3094"
+  OR feature = "WebNfcNdefReaderScan"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webNFCRead.sql
+++ b/sql/timeseries/webNFCRead.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebNfcNdefReaderScan'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3094'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webNFCWrite.sql
+++ b/sql/timeseries/webNFCWrite.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webNFCWrite.sql
+++ b/sql/timeseries/webNFCWrite.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebNfcNdefWriterWrite'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3095'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webOTP.sql
+++ b/sql/timeseries/webOTP.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.SMSReceiverStart'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2880'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webOTP.sql
+++ b/sql/timeseries/webOTP.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webOTP.sql
+++ b/sql/timeseries/webOTP.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.SMSReceiverStart'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2880'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2880"
+  OR feature = "SMSReceiverStart"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webSerial.sql
+++ b/sql/timeseries/webSerial.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webSerial.sql
+++ b/sql/timeseries/webSerial.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.SerialRequestPort'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2546'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2546"
+  OR feature = "SerialRequestPort"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webSerial.sql
+++ b/sql/timeseries/webSerial.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.SerialRequestPort'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2546'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webShareContainingFiles.sql
+++ b/sql/timeseries/webShareContainingFiles.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webShareContainingFiles.sql
+++ b/sql/timeseries/webShareContainingFiles.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebShareSuccessfulContainingFiles'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2872'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2872"
+  OR feature = "WebShareSuccessfulContainingFiles"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webShareContainingFiles.sql
+++ b/sql/timeseries/webShareContainingFiles.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebShareSuccessfulContainingFiles'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2872'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webShareNoFiles.sql
+++ b/sql/timeseries/webShareNoFiles.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebShareSuccessfulWithoutFiles'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2873'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webShareNoFiles.sql
+++ b/sql/timeseries/webShareNoFiles.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webShareNoFiles.sql
+++ b/sql/timeseries/webShareNoFiles.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebShareSuccessfulWithoutFiles'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.2873'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "2873"
+  OR feature = "WebShareSuccessfulWithoutFiles"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webSocketStream.sql
+++ b/sql/timeseries/webSocketStream.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebSocketStreamConstructor'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3018'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "3018"
+  OR feature = "WebSocketStreamConstructor"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC

--- a/sql/timeseries/webSocketStream.sql
+++ b/sql/timeseries/webSocketStream.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.WebSocketStreamConstructor'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.3018'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webSocketStream.sql
+++ b/sql/timeseries/webSocketStream.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webUSB.sql
+++ b/sql/timeseries/webUSB.sql
@@ -4,8 +4,7 @@ SELECT
   UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   client,
   num_urls,
-  ROUND(num_urls / total_urls * 100, 5) AS percent,
-  ANY_VALUE(sample_urls) sample_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent
 FROM
   `httparchive.blink_features.usage`
 WHERE

--- a/sql/timeseries/webUSB.sql
+++ b/sql/timeseries/webUSB.sql
@@ -1,0 +1,18 @@
+#standardSQL
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(IFNULL(
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.UsbRequestDevice'),
+    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1520'))
+  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+FROM
+  `httparchive.pages.*`
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/webUSB.sql
+++ b/sql/timeseries/webUSB.sql
@@ -1,18 +1,23 @@
 #standardSQL
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.UsbRequestDevice'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.1520'))
-  IS NOT NULL, 1, 0)) * 100 / COUNT(0), 5) AS percent
+  REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1_\\2_\\3") AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(yyyymmdd, r"(\d{4})(\d{2})(\d{2})", "\\1-\\2-\\3") AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  num_urls,
+  ROUND(num_urls / total_urls * 100, 5) AS percent,
+  ANY_VALUE(sample_urls) sample_urls,
 FROM
-  `httparchive.pages.*`
+  `httparchive.blink_features.usage`
+WHERE
+  id = "1520"
+  OR feature = "UsbRequestDevice"
 GROUP BY
   date,
   timestamp,
-  client
+  client,
+  num_urls,
+  total_urls
 ORDER BY
   date DESC,
-  client
+  client,
+  num_urls DESC


### PR DESCRIPTION
This PR adds a new top-level report for Project Fugu APIs. It is sorted by the level of maturity of the APIs, starting from (🐡 Launched), over to (🧪 Origin trial), and ending with (🚩 Behind flag).

Some of the reports show no data, since the number of pages that implement these APIs currently is still low. I round to 5 digits in the queries, which, if my math is right and assuming the current size of 5,350,650 URLs of the mobile archive, that there must be at least 0.00001 * 5,350,650 ≈ 54 pages using an API in order for the report to show data.

Please review this jointly with https://github.com/HTTPArchive/httparchive.org/pull/206.