### PR TITLE
Point to the new Getting Started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## HTTP Archive + BigQuery data import
 
-_Note: you don't need to import this data yourself, the BigQuery dataset is public! [Getting started](http://www.igvita.com/2013/06/20/http-archive-bigquery-web-performance-answers/)._
+_Note: you don't need to import this data yourself, the BigQuery dataset is public! [Getting started](https://github.com/HTTPArchive/httparchive.org/blob/master/docs/gettingstarted_bigquery.md)._
 
 However, if you do want your own private copy of the dataset... The following import and sync scripts will help you import the [HTTP Archive dataset](http://httparchive.org/downloads.php) into BigQuery and keep it up to date.
 


### PR DESCRIPTION
The old link describes old BigQuery UI, and I found myself struggling to even find and add HTTP Archive database to the BigQuery instance. The new link instructions worked perfectly, but weren't very discoverable, so swapping one with another seems like the right choice.