### PR TITLE
Reimplement HAR data pipeline with Apache Beam in Python

### DIFF
--- a/dataflow/python/.gitignore
+++ b/dataflow/python/.gitignore
@@ -2,3 +2,5 @@ env
 lib
 adblock.egg*
 local
+credentials/auth.json
+__pycache__

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -45,8 +45,7 @@ python bigquery_import.py \
   --machine_type=n1-standard-32 \
   --input=android-Dec_1_2020 \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink \
-  --requirements_file requirements.txt
+  --experiment=use_beam_bq_sink
   ```
 
   The `--runner=DataflowRunner` option forces the pipeline to run in the cloud using Dataflow. To run locally, omit this option. Be aware that crawls consume TB of disk space, so only run locally using subsetted input datasets. To create a subset dataset, copy a few HAR files on GCS to a new directory.

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -45,7 +45,8 @@ python bigquery_import.py \
   --machine_type=n1-standard-32 \
   --input=android-Dec_1_2020 \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink
+  --experiment=use_beam_bq_sink \
+  --requirements_file requirements.txt
   ```
 
   The `--runner=DataflowRunner` option forces the pipeline to run in the cloud using Dataflow. To run locally, omit this option. Be aware that crawls consume TB of disk space, so only run locally using subsetted input datasets. To create a subset dataset, copy a few HAR files on GCS to a new directory.

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -19,9 +19,11 @@ Follow the [Quickstart using Python](https://cloud.google.com/dataflow/docs/quic
 
 3. Create a service account key, save it to `credentials/cert.json`, and set the environment variable:
 
-	```
-	export GOOGLE_APPLICATION_CREDENTIALS="./credentials/auth.json"
-	```
+```
+export GOOGLE_APPLICATION_CREDENTIALS="./credentials/auth.json"
+```
+
+This needs to be reset during the startup of every shell.
 
 ## Running the pipeline
 
@@ -34,13 +36,16 @@ Follow the [Quickstart using Python](https://cloud.google.com/dataflow/docs/quic
 2. Run `bigquery_import.py`:
 
   ```
-  python bigquery_import.py \
-    --runner=DataflowRunner \
-    --project=httparchive \
-    --temp_location=gs://httparchive/dataflow/temp \
-    --staging_location=gs://httparchive/dataflow/staging \
-    --region=us-central1 \
-    --input android-Mar_24_2020
+python bigquery_import.py \
+  --runner=DataflowRunner \
+  --project=httparchive \
+  --temp_location=gs://httparchive/dataflow/temp \
+  --staging_location=gs://httparchive/dataflow/staging \
+  --region=us-west1 \
+  --machine_type=n1-standard-32 \
+  --input=android-Dec_1_2020 \
+  --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
+  --experiment=use_beam_bq_sink
   ```
 
   The `--runner=DataflowRunner` option forces the pipeline to run in the cloud using Dataflow. To run locally, omit this option. Be aware that crawls consume TB of disk space, so only run locally using subsetted input datasets. To create a subset dataset, copy a few HAR files on GCS to a new directory.

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -4,10 +4,11 @@
 
 Follow the [Quickstart using Python](https://cloud.google.com/dataflow/docs/quickstarts/quickstart-python#before-you-begin) guide.
 
-1. Create a Python 3 `virtualenv`:
+1. Create and activate a Python 3 `virtualenv`:
 
   ```
   python -m virtualenv --python=python3 --clear env
+  source env/bin/activate
   ```
 
 2. Install dependencies:

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -22,3 +22,31 @@ Follow the [Quickstart using Python](https://cloud.google.com/dataflow/docs/quic
 	```
 	export GOOGLE_APPLICATION_CREDENTIALS="./credentials/auth.json"
 	```
+
+## Running the pipeline
+
+1. Activate the Python virtual environment:
+
+  ```
+  source env/bin/activate
+  ```
+
+2. Run `bigquery_import.py`:
+
+  ```
+  python bigquery_import.py \
+    --runner=DataflowRunner \
+    --project=httparchive \
+    --temp_location=gs://httparchive/dataflow/temp \
+    --staging_location=gs://httparchive/dataflow/staging \
+    --region=us-central1 \
+    --input android-Mar_24_2020
+  ```
+
+  The `--runner=DataflowRunner` option forces the pipeline to run in the cloud using Dataflow. To run locally, omit this option. Be aware that crawls consume TB of disk space, so only run locally using subsetted input datasets. To create a subset dataset, copy a few HAR files on GCS to a new directory.
+
+3. Decativate the virtual environment:
+
+  ```
+  deactivate
+  ```

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -1,0 +1,23 @@
+# HTTP Archive Python Dataflow
+
+## Installation
+
+Follow the [Quickstart using Python](https://cloud.google.com/dataflow/docs/quickstarts/quickstart-python#before-you-begin) guide.
+
+1. Create a Python 3 `virtualenv`:
+
+  ```
+  python -m virtualenv --python=python3 --clear env
+  ```
+
+2. Install dependencies:
+
+  ```
+  pip install -r requirements.txt
+  ```
+
+3. Create a service account key, save it to `credentials/cert.json`, and set the environment variable:
+
+	```
+	export GOOGLE_APPLICATION_CREDENTIALS="./credentials/auth.json"
+	```

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import argparse
 from copy import deepcopy
 from datetime import datetime
-import json
 import logging
 import re
 
@@ -13,6 +12,11 @@ import apache_beam as beam
 import apache_beam.io.gcp.gcsio as gcsio
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
+
+try:
+  import ujson as json
+except BaseException:
+  import json
 
 
 # BigQuery can handle rows up to 100 MB.

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -22,62 +22,157 @@
 from __future__ import absolute_import
 
 import argparse
+from datetime import datetime
 import json
 import logging
+import re
 
 import apache_beam as beam
 from apache_beam.io.gcp.internal.clients import bigquery
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
 
 
-def get_url(har):
-  url = har.get('log').get('pages')[0].get('_URL')
-  return {'url': url}
+def get_page(har):
+  """Parses the page from a HAR object."""
+
+  page = har.get('log').get('pages')[0]
+  url = page.get('_URL')
+
+  return {
+    'url': url,
+    'payload': to_json(page)
+  }
 
 
-class Test1(beam.DoFn):
-  def process(self, har):
-    table_spec = bigquery.TableReference(
-      projectId='httparchive',
-      datasetId='scratchspace',
-      tableId='dataflow_test1')
+def get_page_url(har):
+  """Parses the page URL from a HAR object."""
 
-    table_schema = 'url:STRING'
-
-    (har
-      | beam.FlatMap(get_url)
-      | 'BigQueryImport1' >> beam.io.WriteToBigQuery(
-        table_spec,
-        schema=table_schema,
-        write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND,
-        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
-
-    return []
+  return get_page(har).get('url')
 
 
-class Test2(beam.DoFn):
-  def process(self, har):
-    table_spec = bigquery.TableReference(
-      projectId='httparchive',
-      datasetId='scratchspace',
-      tableId='dataflow_test2')
+def get_requests(har):
+  """Parses the requests from a HAR object."""
 
-    table_schema = 'url:STRING'
+  page_url = get_page_url(har)
+  requests = har.get('log').get('entries')
 
-    (har
-      | beam.FlatMap(get_url)
-      | 'BigQueryImport2' >> beam.io.WriteToBigQuery(
-        table_spec,
-        schema=table_schema,
-        write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND,
-        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
+  return [{
+    'page': page_url,
+    'url': request.get('_full_url'),
+    'payload': to_json(trim_request(request))
+  } for request in requests]
 
-    return []
+
+def trim_request(request):
+  """Removes redundant fields from the request object."""
+
+  request.get('response').get('content').pop('text', None)
+  return request
+
+
+def get_technologies(har):
+  """Parses the technologies from a HAR object."""
+  page = har.get('log').get('pages')[0]
+  page_url = page.get('_URL')
+  app_names = page.get('_detected_apps', {})
+  categories = page.get('_detected', {})
+
+  app_map = {}
+  app_list = []
+  for app, info_list in app_names.items():
+    # There may be multiple info values. Add each to the map.
+    for info in info_list.split(','):
+      app_id = '%s %s' % (app, info) if len(info) > 0 else app
+      app_map[app_id] = app
+
+  for category, apps in categories.items():
+    for app_id in apps.split(','):
+      app = app_map.get(app_id)
+      info = ''
+      if app == None:
+        app = app_id
+      else:
+        info = app_id[len(app):].strip()
+      app_list.append({
+        'url': page_url,
+        'category': category,
+        'app': app,
+        'info': info
+      })
+
+  return app_list
+
+
+def get_lighthouse_reports(har):
+  """Parses Lighthouse results from a HAR object."""
+
+  report = har.get('_lighthouse')
+
+  if not report:
+    return
+
+  page_url = get_page_url(har)
+
+  # Omit large UGC.
+  report.get('audits').get('screenshot-thumbnails', {}).get('details', {}).pop('items', None)
+
+  return {
+    'url': page_url,
+    'report': report
+  }
+
+
+def to_json(obj):
+  """Returns a JSON representation of the object.
+
+  This method attempts to mirror the output of the
+  legacy Java Dataflow pipeline. For the most part,
+  the default `json.dumps` config does the trick,
+  but there are a few settings to make it more consistent:
+
+  - Omit whitespace between properties
+  - Do not escape non-ASCII characters (preserve UTF-8)
+
+  One difference between this Python implementation and the
+  Java implementation is the way long numbers are handled.
+  A Python-serialized JSON string might look like this:
+
+    "timestamp":1551686646079.9998
+
+  while the Java-serialized string uses scientific notation:
+
+    "timestamp":1.5516866460799998E12
+
+  Out of a sample of 200 actual request objects, this was
+  the only difference between implementations. This can be
+  considered an improvement.
+
+  """
+
+  return json.dumps(obj, separators=(',', ':'), ensure_ascii=False)
 
 
 def get_gcs_uri(release):
   """Formats a release string into a gs:// file glob."""
 
   return 'gs://httparchive/%s/*.har.gz' % release
+
+
+def get_bigquery_uri(release, dataset):
+  """Formats a release string into a BigQuery dataset/table."""
+
+  client, date_string = release.split('-')
+
+  if client == 'chrome':
+    client = 'desktop'
+  elif client == 'android':
+    client = 'mobile'
+
+  date_obj = datetime.strptime(date_string, '%b_%d_%Y') # Mar_01_2020
+  date_string = date_obj.strftime('%Y_%m_%d') # 2020_03_01
+
+  return 'httparchive:%s.%s_%s' % (dataset, date_string, client)
 
 
 def run(argv=None):
@@ -88,37 +183,51 @@ def run(argv=None):
       required=True,
       help='Input Cloud Storage directory to process.')
   known_args, pipeline_args = parser.parse_known_args(argv)
+  pipeline_options = PipelineOptions(pipeline_args)
+  pipeline_options.view_as(SetupOptions).save_main_session = True
 
 
   with beam.Pipeline(argv=pipeline_args) as p:
-    har = (p
-      | beam.Create(['{"url": "test1", "foo": "abc"}', '{"url": "test2", "foo": "def"}'])
-      | beam.Map(json.loads))
-
-    (har
-      | beam.Map(lambda har: {'url': har.get('url')})
-      | 'Write1' >> beam.io.WriteToBigQuery(
-        'httparchive:scratchspace.dataflow1',
-        schema='url:STRING',
-        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
-        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
-
-    (har
-      | beam.Map(lambda har: {'foo': har.get('foo')})
-      | 'Write2' >> beam.io.WriteToBigQuery(
-        'httparchive:scratchspace.dataflow2',
-        schema='foo:STRING',
-        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
-        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
-'''
     gcs_uri = get_gcs_uri(known_args.input)
 
-    (p
-      | 'read' >> beam.io.ReadFromText(gcs_uri)
-      | 'ParseHAR' >> beam.Map(json.loads)
-      | 'Test1' >> beam.ParDo(Test1())
-      | 'Test2' >> beam.ParDo(Test2()))
-'''
+    hars = (p
+      | 'LoadHARs' >> beam.io.ReadFromText(gcs_uri)
+      | 'ParseHARs' >> beam.Map(json.loads))
+
+    if known_args.input.startswith('android'):
+      (hars
+        | 'MapLighthouseReports' >> beam.Map(get_lighthouse_reports)
+        | 'WriteLighthouseReports' >> beam.io.WriteToBigQuery(
+          get_bigquery_uri(known_args.input, 'lighthouse'),
+          schema='url:STRING, report:STRING',
+          write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+          create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
+
+"""
+    (hars
+      | 'MapTechnologies' >> beam.FlatMap(get_technologies)
+      | 'WriteTechnologies' >> beam.io.WriteToBigQuery(
+        get_bigquery_uri(known_args.input, 'technologies'),
+        schema='url:STRING, category:STRING, app:STRING, info:STRING',
+        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
+
+    (hars
+      | 'MapRequests' >> beam.FlatMap(get_requests)
+      | 'WriteRequests' >> beam.io.WriteToBigQuery(
+        get_bigquery_uri(known_args.input, 'requests'),
+        schema='page:STRING, url:STRING, payload:STRING',
+        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
+
+    (hars
+      | 'MapPages' >> beam.Map(get_page)
+      | 'WritePages' >> beam.io.WriteToBigQuery(
+        get_bigquery_uri(known_args.input, 'pages'),
+        schema='url:STRING, payload:STRING',
+        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
+"""
 
 
 if __name__ == '__main__':

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -34,8 +34,9 @@ def get_page(har):
     logging.warning('Skipping pages payload for "%s": unable to stringify as JSON.' % url)
     return
 
-  if len(payload_json) > MAX_CONTENT_SIZE:
-    logging.warning('Skipping pages payload for "%s": exceeded maximum content size of %s bytes.' % (url, MAX_CONTENT_SIZE))
+  payload_size = len(payload_json)
+  if payload_size > MAX_CONTENT_SIZE:
+    logging.warning('Skipping pages payload for "%s": payload size (%s) exceeds the maximum content size of %s bytes.' % (url, payload_size, MAX_CONTENT_SIZE))
     return
 
   return [{
@@ -47,13 +48,13 @@ def get_page(har):
 def get_page_url(har):
   """Parses the page URL from a HAR object."""
 
-  page = get_page(har)[0]
+  page = get_page(har)
 
   if not page:
     logging.warning('Unable to get URL from page (see preceding warning).')
     return
 
-  return page.get('url')
+  return page[0].get('url')
 
 
 def get_requests(har):
@@ -65,6 +66,8 @@ def get_requests(har):
   page_url = get_page_url(har)
 
   if not page_url:
+    # The page_url field indirectly depends on the get_page function.
+    # If the page data is unavailable for whatever reason, skip its requests.
     logging.warning('Skipping requests payload: unable to get page URL (see preceding warning).')
     return
 
@@ -81,8 +84,9 @@ def get_requests(har):
 
     request_url = request.get('_full_url')
 
-    if len(payload) > MAX_CONTENT_SIZE:
-      logging.warning('Skipping requests payload for "%s": exceeded maximum content size of %s bytes.' % (request_url, MAX_CONTENT_SIZE))
+    payload_size = len(payload)
+    if payload_size > MAX_CONTENT_SIZE:
+      logging.warning('Skipping requests payload for "%s": payload size (%s) exceeded maximum content size of %s bytes.' % (request_url, payload_size, MAX_CONTENT_SIZE))
       continue
 
     requests.append({
@@ -125,7 +129,7 @@ def get_response_bodies(har):
 
     truncated = len(body) > MAX_CONTENT_SIZE
     if truncated:
-      logging.warning('Truncating response body for "%s". Size %s exceeds limit %s.' % (request_url, len(body), MAX_CONTENT_SIZE))
+      logging.warning('Truncating response body for "%s". Response body size %s exceeds limit %s.' % (request_url, len(body), MAX_CONTENT_SIZE))
 
     response_bodies.append({
       'page': page_url,
@@ -207,8 +211,9 @@ def get_lighthouse_reports(har):
     logging.warning('Skipping Lighthouse report for "%s": unable to stringify as JSON.' % page_url)
     return
 
-  if len(report_json) > MAX_CONTENT_SIZE:
-    logging.warning('Skipping Lighthouse report for "%s": exceeded maximum content size of %s bytes.' % (page_url, MAX_CONTENT_SIZE))
+  report_size = len(report_json)
+  if report_size > MAX_CONTENT_SIZE:
+    logging.warning('Skipping Lighthouse report for "%s": Report size (%s) exceeded maximum content size of %s bytes.' % (page_url, report_size, MAX_CONTENT_SIZE))
     return
 
   return [{

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -312,7 +312,7 @@ def run(argv=None):
       | 'MapJSON' >> beam.Map(from_json))
 
     (hars
-      | 'MapPages' >> beam.Map(get_page)
+      | 'MapPages' >> beam.FlatMap(get_page)
       | 'WritePages' >> beam.io.WriteToBigQuery(
         get_bigquery_uri(known_args.input, 'pages'),
         schema='url:STRING, payload:STRING',
@@ -347,7 +347,7 @@ def run(argv=None):
     # Skip Lighthouse for desktop HARs.
     if known_args.input.startswith('android'):
       (hars
-        | 'MapLighthouseReports' >> beam.Map(get_lighthouse_reports)
+        | 'MapLighthouseReports' >> beam.FlatMap(get_lighthouse_reports)
         | 'WriteLighthouseReports' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'lighthouse'),
           schema='url:STRING, report:STRING',

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A word-counting workflow."""
+
+# pytype: skip-file
+
+from __future__ import absolute_import
+
+import argparse
+import logging
+
+import apache_beam as beam
+from apache_beam.io.gcp.internal.clients import bigquery
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+
+
+def do_bigquery_import(har_file):
+  """Workflow to extract BigQuery data from HAR file."""
+
+  return (har_file | 'ExtractHAR' >> beam.Map(lambda har: har_file))
+
+
+def run(argv=None):
+  """Constructs and runs the BigQuery import pipeline."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--input',
+      required=True,
+      help='Input Cloud Storage directory to process.')
+  known_args, pipeline_args = parser.parse_known_args(argv)
+
+
+  with beam.Pipeline(argv=pipeline_args) as p:
+
+    table_spec = bigquery.TableReference(
+      projectId='httparchive',
+      datasetId='scratchspace',
+      tableId='dataflow_test')
+
+    table_schema = 'har:STRING'
+
+    (p 
+      | 'read' >> beam.io.ReadFromText(known_args.input)
+      | 'BigQueryImport' >> beam.io.WriteToBigQuery(
+        table_spec,
+        schema=table_schema,
+        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  run()

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -70,7 +70,6 @@ def get_response_bodies(har):
   for request in requests:
     request_url = request.get('_full_url')
     body = request.get('response').get('content').get('text', '')
-    logging.info('RAV: extracting response body for "%s" of length %s' % (request_url, len(body)))
 
     response_bodies.append({
       'page': page_url,
@@ -209,7 +208,8 @@ def run(argv=None):
     gcs_uri = get_gcs_uri(known_args.input)
 
     hars = (p
-      | 'LoadHARs' >> beam.io.ReadFromText(gcs_uri)
+      | 'GlobHARs' >> beam.Create([gcs_uri])
+      | 'LoadHARs' >> beam.io.ReadAllFromText()
       | 'ParseHARs' >> beam.Map(json.loads))
 
     (hars

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -1,23 +1,4 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-"""A word-counting workflow."""
-
-# pytype: skip-file
+"""HTTP Archive dataflow pipeline for generating HAR data on BigQuery."""
 
 from __future__ import absolute_import
 

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import argparse
 from copy import deepcopy
 from datetime import datetime
+import json
 import logging
 import re
 
@@ -12,11 +13,6 @@ import apache_beam as beam
 import apache_beam.io.gcp.gcsio as gcsio
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-
-try:
-  import ujson as json
-except BaseException:
-  import json
 
 
 # BigQuery can handle rows up to 100 MB.
@@ -42,16 +38,16 @@ def get_page(har):
     logging.warning('Skipping pages payload for "%s": exceeded maximum content size of %s bytes.' % (url, MAX_CONTENT_SIZE))
     return
 
-  return {
+  return [{
     'url': url,
     'payload': payload_json
-  }
+  }]
 
 
 def get_page_url(har):
   """Parses the page URL from a HAR object."""
 
-  page = get_page(har)
+  page = get_page(har)[0]
 
   if not page:
     logging.warning('Unable to get URL from page (see preceding warning).')
@@ -215,10 +211,10 @@ def get_lighthouse_reports(har):
     logging.warning('Skipping Lighthouse report for "%s": exceeded maximum content size of %s bytes.' % (page_url, MAX_CONTENT_SIZE))
     return
 
-  return {
+  return [{
     'url': page_url,
     'report': report_json
-  }
+  }]
 
 
 def to_json(obj):

--- a/dataflow/python/requirements.txt
+++ b/dataflow/python/requirements.txt
@@ -1,0 +1,1 @@
+apache-beam[gcp]

--- a/dataflow/python/requirements.txt
+++ b/dataflow/python/requirements.txt
@@ -1,2 +1,1 @@
-apache-beam[gcp]
-ujson
+apache-beam[gcp]==2.26

--- a/dataflow/python/requirements.txt
+++ b/dataflow/python/requirements.txt
@@ -1,1 +1,2 @@
 apache-beam[gcp]
+ujson

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -1,6 +1,7 @@
 # Omit the runner option to run the pipeline locally.
 #--runner=DataflowRunner \
 python bigquery_import.py \
+  --runner=DataflowRunner \
   --project=httparchive \
   --temp_location=gs://httparchive/dataflow/temp \
 	--staging_location=gs://httparchive/dataflow/staging \

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -7,6 +7,6 @@ python bigquery_import.py \
   --staging_location=gs://httparchive/dataflow/staging \
   --region=us-west1 \
   --machine_type=n1-standard-32 \
-  --input=chrome-Dec_1_2020 \
+  --input=chrome-Nov_1_2020 \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
   --experiment=use_beam_bq_sink

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -7,4 +7,5 @@ python bigquery_import.py \
   --staging_location=gs://httparchive/dataflow/staging \
   --region=us-central1 \
   --machine_type=n1-standard-4 \
-  --input android-Mar_1_2020
+  --input android-Mar_1_2020 \
+  --experiment=use_beam_bq_sink

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -6,4 +6,5 @@ python bigquery_import.py \
   --temp_location=gs://httparchive/dataflow/temp \
   --staging_location=gs://httparchive/dataflow/staging \
   --region=us-central1 \
+  --machine_type=n1-standard-4 \
   --input android-Mar_1_2020

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -7,6 +7,6 @@ python bigquery_import.py \
   --staging_location=gs://httparchive/dataflow/staging \
   --region=us-west1 \
   --machine_type=n1-standard-32 \
-  --input android-Dec_1_2020 \
+  --input=android-Dec_1_2020 \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
   --experiment=use_beam_bq_sink

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -5,7 +5,8 @@ python bigquery_import.py \
   --project=httparchive \
   --temp_location=gs://httparchive/dataflow/temp \
   --staging_location=gs://httparchive/dataflow/staging \
-  --region=us-central1 \
-  --machine_type=n1-standard-4 \
-  --input android-Mar_1_2020 \
+  --region=us-west1 \
+  --machine_type=n1-standard-32 \
+  --input android-Dec_1_2020 \
+  --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
   --experiment=use_beam_bq_sink

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -7,6 +7,6 @@ python bigquery_import.py \
   --staging_location=gs://httparchive/dataflow/staging \
   --region=us-west1 \
   --machine_type=n1-standard-32 \
-  --input=android-Dec_1_2020 \
+  --input=chrome-Dec_1_2020 \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
   --experiment=use_beam_bq_sink

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -1,4 +1,7 @@
+# Omit the runner option to run the pipeline locally.
+#--runner=DataflowRunner \
 python bigquery_import.py \
-	--project=httparchive \
-	--stagingLocation=gs://httparchive/dataflow/staging \
-	--input chrome-Mar_24_2020 > /tmp/dataflow
+  --project=httparchive \
+  --temp_location=gs://httparchive/dataflow/temp \
+	--staging_location=gs://httparchive/dataflow/staging \
+	--input android-Mar_24_2020

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -9,4 +9,5 @@ python bigquery_import.py \
   --machine_type=n1-standard-32 \
   --input=chrome-Dec_1_2020 \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink
+  --experiment=use_beam_bq_sink \
+  --requirements_file requirements.txt

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -9,5 +9,4 @@ python bigquery_import.py \
   --machine_type=n1-standard-32 \
   --input=chrome-Dec_1_2020 \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink \
-  --requirements_file requirements.txt
+  --experiment=use_beam_bq_sink

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -4,5 +4,6 @@ python bigquery_import.py \
   --runner=DataflowRunner \
   --project=httparchive \
   --temp_location=gs://httparchive/dataflow/temp \
-	--staging_location=gs://httparchive/dataflow/staging \
-	--input android-Mar_24_2020
+  --staging_location=gs://httparchive/dataflow/staging \
+  --region=us-central1 \
+  --input android-Mar_1_2020

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -1,4 +1,4 @@
 python bigquery_import.py \
 	--project=httparchive \
 	--stagingLocation=gs://httparchive/dataflow/staging \
-	--input gs://httparchive/chrome-Mar_24_2020/
+	--input chrome-Mar_24_2020 > /tmp/dataflow

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -1,0 +1,4 @@
+python bigquery_import.py \
+	--project=httparchive \
+	--stagingLocation=gs://httparchive/dataflow/staging \
+	--input gs://httparchive/chrome-Mar_24_2020/

--- a/sync_har.sh
+++ b/sync_har.sh
@@ -78,7 +78,8 @@ python bigquery_import.py \
   --machine_type=n1-standard-32 \
   --input="${bucket}" \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink
+  --experiment=use_beam_bq_sink \
+  --requirements_file requirements.txt
 
 deactivate
 

--- a/sync_har.sh
+++ b/sync_har.sh
@@ -78,8 +78,7 @@ python bigquery_import.py \
   --machine_type=n1-standard-32 \
   --input="${bucket}" \
   --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink \
-  --requirements_file requirements.txt
+  --experiment=use_beam_bq_sink
 
 deactivate
 


### PR DESCRIPTION
This replaces the obsolete Java Dataflow SDK, which hasn't worked since October 2020. The implementation uses the latest Apache Beam Python SDK, version 2.26.0. It introduces new dependencies to the pipeline, so the GCE worker responsible for executing `sync_har.sh` must also follow the installation instructions in the README, including a secret `credentials/auth.json` file with service account credentials to run the Dataflow jobs.

I did also try to use `ujson` instead of `json` for possible performance gains, but ran into dependency issues on Dataflow. The pipeline runs without it, albeit slowly, so this is something we can defer for future optimizations.

Fixes https://github.com/HTTPArchive/httparchive.org/issues/232