### PR TITLE
Add CWV extracts

### DIFF
--- a/sql/timeseries/cruxFastFid.sql
+++ b/sql/timeseries/cruxFastFid.sql
@@ -7,7 +7,7 @@ SELECT
 FROM
   `chrome-ux-report.materialized.device_summary`
 WHERE
-  yyyymm >= "201806"
+  yyyymm >= 201806
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxFastLcp.sql
+++ b/sql/timeseries/cruxFastLcp.sql
@@ -1,0 +1,17 @@
+#standardSQL
+SELECT
+  REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(fast_lcp) * 100 / (SUM(fast_lcp) + SUM(avg_lcp) + SUM(slow_lcp)), 2) AS percent
+FROM
+  `chrome-ux-report.materialized.device_summary`
+WHERE
+  yyyymm >= 201909
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/cruxLargeCls.sql
+++ b/sql/timeseries/cruxLargeCls.sql
@@ -1,0 +1,17 @@
+#standardSQL
+SELECT
+  REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(larg_cls) * 100 / (SUM(small_cls) + SUM(medium_cls) + SUM(large_cls)), 2) AS percent
+FROM
+  `chrome-ux-report.materialized.device_summary`
+WHERE
+  yyyymm >= 201905
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/cruxSlowFid.sql
+++ b/sql/timeseries/cruxSlowFid.sql
@@ -7,7 +7,7 @@ SELECT
 FROM
   `chrome-ux-report.materialized.device_summary`
 WHERE
-  yyyymm >= "201806"
+  yyyymm >= 201806
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxSlowLcp.sql
+++ b/sql/timeseries/cruxSlowLcp.sql
@@ -1,0 +1,17 @@
+#standardSQL
+SELECT
+  REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(slow_lcp) * 100 / (SUM(fast_lcp) + SUM(avg_lcp) + SUM(slow_lcp)), 2) AS percent
+FROM
+  `chrome-ux-report.materialized.device_summary`
+WHERE
+  yyyymm >= 201909
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/cruxSmallCls.sql
+++ b/sql/timeseries/cruxSmallCls.sql
@@ -1,0 +1,17 @@
+#standardSQL
+SELECT
+  REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
+  UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  ROUND(SUM(small_cls) * 100 / (SUM(small_cls) + SUM(medium_cls) + SUM(large_cls)), 2) AS percent
+FROM
+  `chrome-ux-report.materialized.device_summary`
+WHERE
+  yyyymm >= 201905
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client


### PR DESCRIPTION
Was curious if any change to CWV but LCP and CLS aren't tracked in the CrUX report so this SQL adds the extracts. Will add the reports as well after they run.

Know you're talking about redoing this report to make it more CWV centric, but not sure when that will happen and these queries are very cheap so might as well add them in meantime.