### PR TITLE
Add ability to run just a subset of reports like CrUX

### DIFF
--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -24,6 +24,7 @@ FORCE=0
 GENERATE_HISTOGRAM=0
 GENERATE_TIMESERIES=0
 LENS=""
+REPORTS="*"
 
 # Read the flags.
 while getopts ":fth:l:" opt; do
@@ -42,6 +43,9 @@ while getopts ":fth:l:" opt; do
 			;;
 		l)
 			LENS=${OPTARG}
+			;;
+		r)
+			REPORTS=${OPTARG}
 			;;
 	esac
 done
@@ -80,7 +84,7 @@ else
 	echo -e "Generating histograms for date $YYYY_MM_DD"
 
 	# Run all histogram queries.
-	for query in sql/histograms/*.sql; do
+	for query in sql/histograms/$REPORTS.sql; do
 		# Extract the metric name from the file path.
 		# For example, `sql/histograms/foo.sql` will produce `foo`.
 		metric=$(echo $(basename $query) | cut -d"." -f1)
@@ -125,7 +129,7 @@ else
 	echo -e "Generating timeseries"
 
 	# Run all timeseries queries.
-	for query in sql/timeseries/*.sql; do
+	for query in sql/timeseries/$REPORTS.sql; do
 		# Extract the metric name from the file path.
 		metric=$(echo $(basename $query) | cut -d"." -f1)
 


### PR DESCRIPTION
This adds a `-r` option to allow you to run just a subset of reports.

For example you can run just the CrUX reports (as that data comes in later) with the following command:

```
./sql/generate_reports.sh -fth 2021_04_01 -r "*crux*"
```

Or for last month:

```
./sql/generate_reports.sh -fth `date -d '-1 month' '+%Y_%m_01'` -r "*crux*"
```

We can then cron this up to kick off the CrUX reports after the second Tuesday of the month (when data should be available) to keep these reports updated.
