### PR TITLE
Set up CrUX reports to run on cron

### DIFF
--- a/crontab
+++ b/crontab
@@ -3,3 +3,6 @@
 
 0 10 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_har.sh chrome' >> /var/log/HA-import-har-chrome.log 2>&1
 0 11 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_har.sh android' >> /var/log/HA-import-har-android.log 2>&1
+
+0 6 14 * * /bin/bash -l -c 'cd /home/igrigorik/code && sql/generate_reports.sh -fth `date -d "-1 month" "+\%Y_\%m_01"` -r "*crux*"' >> /var/log/crux_reruns.logmor 2>&1
+0 7 14 * * /bin/bash -l -c 'cd /home/igrigorik/code && ls -1 sql/lens | xargs -I lens sql/generate_reports.sh -fth `date -d "-1 month" "+\%Y_\%m_01"` -r "*crux*" -l lens' >> /var/log/crux_reruns.log 2>&1

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -16,6 +16,8 @@
 #
 #   -l: Optional name of the report lens to generate, eg "wordpress".
 #
+#   -r: Optional name of the report files to generate, eg "*crux*".
+#
 
 set -o pipefail
 
@@ -27,7 +29,7 @@ LENS=""
 REPORTS="*"
 
 # Read the flags.
-while getopts ":fth:l:" opt; do
+while getopts ":fth:lr:" opt; do
 	case "${opt}" in
 		h)
 			GENERATE_HISTOGRAM=1


### PR DESCRIPTION
Runs the CrUX reports on the 14th day of the month for the previous date - by which time the data should be ready.