### PR TITLE
Change CrUX queries to look at number of sites that passed

### DIFF
--- a/sql/timeseries/cruxFastDcl.sql
+++ b/sql/timeseries/cruxFastDcl.sql
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastDcl.sql
+++ b/sql/timeseries/cruxFastDcl.sql
@@ -1,15 +1,48 @@
 #standardSQL
+# Fast Dopm Content Loaded by device
+
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_dcl,
+    avg_dcl,
+    slow_dcl
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(fast_dcl) * 100 / (SUM(fast_dcl) + SUM(avg_dcl) + SUM(slow_dcl)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_GOOD(fast_dcl, avg_dcl, slow_dcl), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_dcl, avg_dcl, slow_dcl), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
+WHERE
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastDcl.sql
+++ b/sql/timeseries/cruxFastDcl.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_dcl,
@@ -29,7 +29,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_GOOD(fast_dcl, avg_dcl, slow_dcl), origin, NULL)), 
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastDcl.sql
+++ b/sql/timeseries/cruxFastDcl.sql
@@ -9,23 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_dcl,
-    avg_dcl,
-    slow_dcl
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -34,9 +17,9 @@ SELECT
       COUNT(DISTINCT IF(
           IS_GOOD(fast_dcl, avg_dcl, slow_dcl), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_dcl, avg_dcl, slow_dcl), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_dcl, avg_dcl, slow_dcl), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
 GROUP BY

--- a/sql/timeseries/cruxFastFcp.sql
+++ b/sql/timeseries/cruxFastFcp.sql
@@ -9,23 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_fcp,
-    avg_fcp,
-    slow_fcp
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -34,9 +17,9 @@ SELECT
       COUNT(DISTINCT IF(
           IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
 GROUP BY

--- a/sql/timeseries/cruxFastFcp.sql
+++ b/sql/timeseries/cruxFastFcp.sql
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFcp.sql
+++ b/sql/timeseries/cruxFastFcp.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_fcp,
@@ -29,7 +29,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)), 
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFcp.sql
+++ b/sql/timeseries/cruxFastFcp.sql
@@ -1,15 +1,48 @@
 #standardSQL
+# Fast FCP by device
+
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_fcp,
+    avg_fcp,
+    slow_fcp
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(fast_fcp) * 100 / (SUM(fast_fcp) + SUM(avg_fcp) + SUM(slow_fcp)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_GOOD(fast_fcp, avg_fcp, slow_fcp), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
+WHERE
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFid.sql
+++ b/sql/timeseries/cruxFastFid.sql
@@ -1,17 +1,53 @@
 #standardSQL
+# Fast FID by device
+
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  poor / (good + needs_improvement + poor) >= 0.25
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_fid,
+    avg_fid,
+    slow_fid
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+    AND yyyymm >= 201806
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(fast_fid) * 100 / (SUM(fast_fid) + SUM(avg_fid) + SUM(slow_fid)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
 WHERE
-  yyyymm >= 201806
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFid.sql
+++ b/sql/timeseries/cruxFastFid.sql
@@ -47,7 +47,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFid.sql
+++ b/sql/timeseries/cruxFastFid.sql
@@ -17,7 +17,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_fid,
@@ -34,7 +34,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_GOOD(fast_fid, avg_fid, slow_fid), origin, NULL)), 
@@ -47,7 +47,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFp.sql
+++ b/sql/timeseries/cruxFastFp.sql
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFp.sql
+++ b/sql/timeseries/cruxFastFp.sql
@@ -1,15 +1,48 @@
 #standardSQL
+# Fast First Paint by device
+
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_fp,
+    avg_fp,
+    slow_fp
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(fast_fp) * 100 / (SUM(fast_fp) + SUM(avg_fp) + SUM(slow_fp)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_GOOD(fast_fp, avg_fp, slow_fp), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_fp, avg_fp, slow_fp), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
+WHERE
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastFp.sql
+++ b/sql/timeseries/cruxFastFp.sql
@@ -9,23 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_fp,
-    avg_fp,
-    slow_fp
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -34,9 +17,9 @@ SELECT
       COUNT(DISTINCT IF(
           IS_GOOD(fast_fp, avg_fp, slow_fp), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fp, avg_fp, slow_fp), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_fp, avg_fp, slow_fp), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
 GROUP BY

--- a/sql/timeseries/cruxFastFp.sql
+++ b/sql/timeseries/cruxFastFp.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_fp,
@@ -29,7 +29,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_GOOD(fast_fp, avg_fp, slow_fp), origin, NULL)), 
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastLcp.sql
+++ b/sql/timeseries/cruxFastLcp.sql
@@ -52,7 +52,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastLcp.sql
+++ b/sql/timeseries/cruxFastLcp.sql
@@ -9,24 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_lcp,
-    avg_lcp,
-    slow_lcp
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-    AND yyyymm >= 201909
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -35,11 +17,12 @@ SELECT
       COUNT(DISTINCT IF(
           IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
+    AND yyyymm >= 201909
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxFastLcp.sql
+++ b/sql/timeseries/cruxFastLcp.sql
@@ -1,17 +1,58 @@
 #standardSQL
+# Fast LCP by device
+
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NI (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) < 0.75
+  AND poor / (good + needs_improvement + poor) < 0.25
+);
+
+CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  poor / (good + needs_improvement + poor) >= 0.25
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_lcp,
+    avg_lcp,
+    slow_lcp
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+    AND yyyymm >= 201909
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(fast_lcp) * 100 / (SUM(fast_lcp) + SUM(avg_lcp) + SUM(slow_lcp)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
 WHERE
-  yyyymm >= 201909
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastLcp.sql
+++ b/sql/timeseries/cruxFastLcp.sql
@@ -22,7 +22,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_lcp,
@@ -39,7 +39,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_GOOD(fast_lcp, avg_lcp, slow_lcp), origin, NULL)), 
@@ -52,7 +52,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastOl.sql
+++ b/sql/timeseries/cruxFastOl.sql
@@ -1,15 +1,48 @@
 #standardSQL
+# Fast Onload by device
+
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_ol,
+    avg_ol,
+    slow_ol
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(fast_ol) * 100 / (SUM(fast_ol) + SUM(avg_ol) + SUM(slow_ol)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_GOOD(fast_ol, avg_ol, slow_ol), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_ol, avg_ol, slow_ol), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
+WHERE
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastOl.sql
+++ b/sql/timeseries/cruxFastOl.sql
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastOl.sql
+++ b/sql/timeseries/cruxFastOl.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_ol,
@@ -29,7 +29,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_GOOD(fast_ol, avg_ol, slow_ol), origin, NULL)), 
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxFastOl.sql
+++ b/sql/timeseries/cruxFastOl.sql
@@ -9,23 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_ol,
-    avg_ol,
-    slow_ol
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -34,9 +17,9 @@ SELECT
       COUNT(DISTINCT IF(
           IS_GOOD(fast_ol, avg_ol, slow_ol), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_ol, avg_ol, slow_ol), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_ol, avg_ol, slow_ol), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
 GROUP BY

--- a/sql/timeseries/cruxLargeCls.sql
+++ b/sql/timeseries/cruxLargeCls.sql
@@ -1,17 +1,49 @@
 #standardSQL
+# Large CLS by device
+
+CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  poor / (good + needs_improvement + poor) >= 0.25
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+    
+    small_cls,
+    medium_cls,
+    large_cls
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+    AND yyyymm >= 201905
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(large_cls) * 100 / (SUM(small_cls) + SUM(medium_cls) + SUM(large_cls)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
 WHERE
-  yyyymm >= 201905
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxLargeCls.sql
+++ b/sql/timeseries/cruxLargeCls.sql
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxLargeCls.sql
+++ b/sql/timeseries/cruxLargeCls.sql
@@ -9,24 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-    
-    small_cls,
-    medium_cls,
-    large_cls
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-    AND yyyymm >= 201905
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -35,11 +17,12 @@ SELECT
       COUNT(DISTINCT IF(
           IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS percent
+          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
+  AND yyyymm >= 201905
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxLargeCls.sql
+++ b/sql/timeseries/cruxLargeCls.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
     
     small_cls,
@@ -30,7 +30,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_POOR(small_cls, medium_cls, large_cls), origin, NULL)), 
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxPassesCWV.sql
+++ b/sql/timeseries/cruxPassesCWV.sql
@@ -15,18 +15,17 @@ SELECT
   IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
-          IS_GOOD(fast_fid, avg_fid, slow_fid) AND
-          IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
-      COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) * 100 AS percent,
+          /* FID can be null quite often, and LCP and CLS less so */
+          (p75_fid IS NULL OR IS_GOOD(fast_fid, avg_fid, slow_fid)) AND
+          (p75_lcp IS NULL OR IS_GOOD(fast_lcp, avg_lcp, slow_lcp)) AND
+          (p75_cls IS NULL OR IS_GOOD(small_cls, medium_cls, large_cls)), origin, NULL)),
+      COUNT(DISTINCT origin)) * 100 AS percent,
 FROM
   `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
-  AND yyyymm >= 201909
+  AND yyyymm > 201909
+  AND (p75_fid IS NOT NULL OR p75_lcp IS NOT NULL OR p75_cls IS NOT NULL) /* Must have at least one CWV */
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxPassesCWV.sql
+++ b/sql/timeseries/cruxPassesCWV.sql
@@ -15,17 +15,17 @@ SELECT
   IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
-          /* FID can be null quite often, and LCP and CLS less so */
+          /* FID can be null and is not mandatory for CWV */
           (p75_fid IS NULL OR IS_GOOD(fast_fid, avg_fid, slow_fid)) AND
-          (p75_lcp IS NULL OR IS_GOOD(fast_lcp, avg_lcp, slow_lcp)) AND
-          (p75_cls IS NULL OR IS_GOOD(small_cls, medium_cls, large_cls)), origin, NULL)),
+          IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
+          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
       COUNT(DISTINCT origin)) * 100 AS percent
 FROM
   `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
   AND yyyymm > 201909
-  AND (p75_fid IS NOT NULL OR p75_lcp IS NOT NULL OR p75_cls IS NOT NULL) /* Must have at least one CWV */
+  AND p75_lcp IS NOT NULL AND p75_cls IS NOT NULL /* Must have LCP and CLS */
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxPassesCWV.sql
+++ b/sql/timeseries/cruxPassesCWV.sql
@@ -9,32 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_fid,
-    avg_fid,
-    slow_fid,
-
-    fast_lcp,
-    avg_lcp,
-    slow_lcp,
-
-    small_cls,
-    medium_cls,
-    large_cls
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-    AND yyyymm >= 201909
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -47,11 +21,12 @@ SELECT
       COUNT(DISTINCT IF(
           IS_NON_ZERO(fast_fid, avg_fid, slow_fid) AND
           IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp) AND
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS percent,
+          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) * 100 AS percent,
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
+  AND yyyymm >= 201909
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxPassesCWV.sql
+++ b/sql/timeseries/cruxPassesCWV.sql
@@ -19,7 +19,7 @@ SELECT
           (p75_fid IS NULL OR IS_GOOD(fast_fid, avg_fid, slow_fid)) AND
           (p75_lcp IS NULL OR IS_GOOD(fast_lcp, avg_lcp, slow_lcp)) AND
           (p75_cls IS NULL OR IS_GOOD(small_cls, medium_cls, large_cls)), origin, NULL)),
-      COUNT(DISTINCT origin)) * 100 AS percent,
+      COUNT(DISTINCT origin)) * 100 AS percent
 FROM
   `chrome-ux-report.materialized.device_summary`
 WHERE

--- a/sql/timeseries/cruxSlowFcp.sql
+++ b/sql/timeseries/cruxSlowFcp.sql
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowFcp.sql
+++ b/sql/timeseries/cruxSlowFcp.sql
@@ -1,15 +1,48 @@
 #standardSQL
+# Slow FCP by device
+
+CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  poor / (good + needs_improvement + poor) >= 0.25
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_fcp,
+    avg_fcp,
+    slow_fcp
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(slow_fcp) * 100 / (SUM(fast_fcp) + SUM(avg_fcp) + SUM(slow_fcp)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
+WHERE
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowFcp.sql
+++ b/sql/timeseries/cruxSlowFcp.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_fcp,
@@ -29,7 +29,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)), 
@@ -42,7 +42,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowFcp.sql
+++ b/sql/timeseries/cruxSlowFcp.sql
@@ -9,23 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_fcp,
-    avg_fcp,
-    slow_fcp
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -34,9 +17,9 @@ SELECT
       COUNT(DISTINCT IF(
           IS_POOR(fast_fcp, avg_fcp, slow_fcp), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_fcp, avg_fcp, slow_fcp), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
 GROUP BY

--- a/sql/timeseries/cruxSlowFid.sql
+++ b/sql/timeseries/cruxSlowFid.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_fid,
@@ -30,7 +30,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)), 
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowFid.sql
+++ b/sql/timeseries/cruxSlowFid.sql
@@ -1,17 +1,49 @@
 #standardSQL
+# Slow FID by device
+
+CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  poor / (good + needs_improvement + poor) >= 0.25
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_fid,
+    avg_fid,
+    slow_fid
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+    AND yyyymm >= 201806
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(slow_fid) * 100 / (SUM(fast_fid) + SUM(avg_fid) + SUM(slow_fid)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
 WHERE
-  yyyymm >= 201806
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowFid.sql
+++ b/sql/timeseries/cruxSlowFid.sql
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowFid.sql
+++ b/sql/timeseries/cruxSlowFid.sql
@@ -9,24 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_fid,
-    avg_fid,
-    slow_fid
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-    AND yyyymm >= 201806
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -35,11 +17,12 @@ SELECT
       COUNT(DISTINCT IF(
           IS_POOR(fast_fid, avg_fid, slow_fid), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_fid, avg_fid, slow_fid), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
+    AND yyyymm >= 201806
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxSlowLcp.sql
+++ b/sql/timeseries/cruxSlowLcp.sql
@@ -9,24 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-
-    fast_lcp,
-    avg_lcp,
-    slow_lcp
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-    AND yyyymm >= 201909
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -35,11 +17,12 @@ SELECT
       COUNT(DISTINCT IF(
           IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS percent
+          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
+    AND yyyymm >= 201909
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxSlowLcp.sql
+++ b/sql/timeseries/cruxSlowLcp.sql
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowLcp.sql
+++ b/sql/timeseries/cruxSlowLcp.sql
@@ -1,17 +1,49 @@
 #standardSQL
+# Slow LCP by device
+
+CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  poor / (good + needs_improvement + poor) >= 0.25
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+
+    fast_lcp,
+    avg_lcp,
+    slow_lcp
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+    AND yyyymm >= 201909
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(slow_lcp) * 100 / (SUM(fast_lcp) + SUM(avg_lcp) + SUM(slow_lcp)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(fast_lcp, avg_lcp, slow_lcp), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
 WHERE
-  yyyymm >= 201909
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSlowLcp.sql
+++ b/sql/timeseries/cruxSlowLcp.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
 
     fast_lcp,
@@ -30,7 +30,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_POOR(fast_lcp, avg_lcp, slow_lcp), origin, NULL)), 
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSmallCls.sql
+++ b/sql/timeseries/cruxSmallCls.sql
@@ -13,7 +13,7 @@ WITH
   base AS (
   SELECT
     yyyymm,
-    origin,
+    origin,
     device,
     
     small_cls,
@@ -30,7 +30,7 @@ WITH
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
       COUNT(DISTINCT IF(
           IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)), 
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  client
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSmallCls.sql
+++ b/sql/timeseries/cruxSmallCls.sql
@@ -43,7 +43,7 @@ WHERE
 GROUP BY
   date,
   timestamp,
-  device
+  client
 ORDER BY
   date DESC,
   client

--- a/sql/timeseries/cruxSmallCls.sql
+++ b/sql/timeseries/cruxSmallCls.sql
@@ -9,24 +9,6 @@ CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor 
   good + needs_improvement + poor > 0
 );
 
-WITH
-  base AS (
-  SELECT
-    yyyymm,
-    origin,
-    device,
-    
-    small_cls,
-    medium_cls,
-    large_cls
-
-  FROM
-    `chrome-ux-report.materialized.device_summary`
-  WHERE
-    device IN ('desktop','phone')
-    AND yyyymm >= 201905
-  )
-
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
@@ -35,11 +17,12 @@ SELECT
       COUNT(DISTINCT IF(
           IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)), 
       COUNT(DISTINCT IF(
-          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS percent
+          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) * 100 AS percent
 FROM
-  base
+  `chrome-ux-report.materialized.device_summary`
 WHERE
   device IN ('desktop','phone')
+    AND yyyymm >= 201905
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/cruxSmallCls.sql
+++ b/sql/timeseries/cruxSmallCls.sql
@@ -1,17 +1,49 @@
 #standardSQL
+# Small CLS by device
+
+CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good / (good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH
+  base AS (
+  SELECT
+    yyyymm,
+    origin,
+    device,
+    
+    small_cls,
+    medium_cls,
+    large_cls
+
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  WHERE
+    device IN ('desktop','phone')
+    AND yyyymm >= 201905
+  )
+
 SELECT
   REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1_\\2_01') AS date,
   UNIX_DATE(CAST(REGEXP_REPLACE(CAST(yyyymm AS STRING), '(\\d{4})(\\d{2})', '\\1-\\2-01') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(device = 'desktop', 'desktop', 'mobile') AS client,
-  ROUND(SUM(small_cls) * 100 / (SUM(small_cls) + SUM(medium_cls) + SUM(large_cls)), 2) AS percent
+  IF(device = 'desktop', 'desktop', 'mobile') AS client,
+  SAFE_DIVIDE(
+      COUNT(DISTINCT IF(
+          IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)), 
+      COUNT(DISTINCT IF(
+          IS_NON_ZERO(small_cls, medium_cls, large_cls), origin, NULL))) AS percent
 FROM
-  `chrome-ux-report.materialized.device_summary`
+  base
 WHERE
-  yyyymm >= 201905
+  device IN ('desktop','phone')
 GROUP BY
   date,
   timestamp,
-  client
+  device
 ORDER BY
   date DESC,
   client


### PR DESCRIPTION
As discussed with @rviscomi we differ what we [show in our CrUX report](https://httparchive.org/reports/chrome-ux-report) and [what CrUX announces](https://groups.google.com/a/chromium.org/g/chrome-ux-report-announce/c/wQyI4jUJlYQ).

Previously we were looking at the percentage of "good" or "poor" percentages across all sites. This change makes it look at the count of sites for "good" or "poor" instead, which is a better metric.