### PR TITLE
Add HTTP/3 SQL query

### DIFF
--- a/sql/timeseries/h3.sql
+++ b/sql/timeseries/h3.sql
@@ -1,0 +1,32 @@
+#standardSQL
+# The amount of requests either using HTTP/3 or able to use it.
+#
+# We measure "ability to use" as well as "actual use", as HTTP Archive is a
+# cold crawl and so less likely to use HTTP/3 which requires prior visits.
+# 
+# For "able to use" we look at the alt-svc response header.
+#
+# We also only measure official HTTP/3 (ALPN h3, h3-29) and not gQUIC or other
+# prior versions. h3-29 is the final draft version and will be switched to h3
+# when HTTP/3 is approved so we include that as it is HTTP/3 in all but name.
+#
+SELECT
+  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+  ROUND(SUM(IF(respHttpVersion = 'HTTP/3' OR respHttpVersion = 'h3' OR respHttpVersion = 'h3-29'
+                OR reqHttpVersion = 'HTTP/3' OR reqHttpVersion = 'h3' OR reqHttpVersion = 'h3-29'
+                OR REGEXP_EXTRACT(REGEXP_EXTRACT(respOtherHeaders, r'alt-svc = (.*)'), r'(.*?)(?:, [^ ]* = .*)?$') LIKE '%h3=%'
+                OR REGEXP_EXTRACT(REGEXP_EXTRACT(respOtherHeaders, r'alt-svc = (.*)'), r'(.*?)(?:, [^ ]* = .*)?$') LIKE '%h3-29=%'
+              , 1, 0)) * 100 / COUNT(0), 2) AS percent
+FROM
+  `httparchive.summary_requests.*`
+WHERE
+  SUBSTR(_TABLE_SUFFIX, 0, 10) >= '2020_01_01'
+GROUP BY
+  date,
+  timestamp,
+  client
+ORDER BY
+  date DESC,
+  client

--- a/sql/timeseries/h3.sql
+++ b/sql/timeseries/h3.sql
@@ -14,8 +14,8 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(respHttpVersion = 'HTTP/3' OR respHttpVersion = 'h3' OR respHttpVersion = 'h3-29'
-                OR reqHttpVersion = 'HTTP/3' OR reqHttpVersion = 'h3' OR reqHttpVersion = 'h3-29'
+  ROUND(SUM(IF(respHttpVersion IN ('HTTP/3', 'h3', 'h3-29')
+                OR reqHttpVersion IN ('HTTP/3', 'h3', 'h3-29')
                 OR REGEXP_EXTRACT(REGEXP_EXTRACT(respOtherHeaders, r'alt-svc = (.*)'), r'(.*?)(?:, [^ ]* = .*)?$') LIKE '%h3=%'
                 OR REGEXP_EXTRACT(REGEXP_EXTRACT(respOtherHeaders, r'alt-svc = (.*)'), r'(.*?)(?:, [^ ]* = .*)?$') LIKE '%h3-29=%'
               , 1, 0)) * 100 / COUNT(0), 2) AS percent


### PR DESCRIPTION
HTTP/3 is here! Well QUIC is and HTTP/3 is not far behind. We've [already noticed HTTP/2 dropping because of this](https://twitter.com/HTTPArchive/status/1407812431112552449) so think we should add an HTTP/3 graph, so adding the query is the first part of this.

There's a few complexities to consider compared to the equivalent HTTP/2 graph:

The HTTP/2 query is **ridiculously expensive** (see #110 ). I've gone for the cheaper suggestion for HTTP/3 since we don't need that historical data when the data was wrong. It's not quite as cheap as the HTTP/2 suggestion as need to look at `alt-svc` response header (for reasons I'll discuss below), but still it's only $15 as opposed to $1,000+.

HTTP/3 has been around for a while in pre-release versions and arguably Google's QUIC could be included in this going back nearly 10 years. However I've decided to limit this to HTTP/3 (aka `h3`), however I have included the last draft version (`h3-29`) as that is what will become HTTP/3 as soon as the IETF signs of the RFCs — so it is HTTP/3 in all but name. It is also what is being used now, and so explains the offset from HTTP/2 dropping, whereas waiting for `h3` will show a delay between that drop, and this ramp up. That `h3-29` version started appearing from June 2020 so the graph will start before HTTP/3 officially exists but think that's OK. [This sheet](https://docs.google.com/spreadsheets/d/1qIqGh0TRxMrfaOXcNsn2CwFT0cCukpy2OD5Xx17USuM/edit#gid=0) ran the query for a few combinations and current usage is from 0% (pure HTTP/3 or `h3`), 9-10% (HTTP/3, `h3` or `h3-29`), slightly higher 9-10% for all versions of `h3`, and 11.5% if we also include Google's QUIC. So I think the second option is the right one.

HTTP/3 will often not be used by our crawl. This is because, by default the browser uses TCP and then receives an `alt-svc` header saying "hey I support HTTP/3, so next time you're talking to me why not use that." If it needs to open another connection (e.g. an uncredentialled connection for Fetch or the like) then it might use HTTP/3, but it's not gonna be consistent. This is different to HTTP/2 where it's negotiated as part of HTTPS so should be used if supported. So, rather than measure HTTP/3 *usage*, I've decided to measure HTTP/3 *support* by looking at protocol used **OR** `alt-svc` support. Got [some support](https://twitter.com/programmingart/status/1407820884249882625?s=20) online for this approach. Will need to add an explanation to the chart when we add this to the site to explain this difference from HTTP/2 and how it may double count usage in both HTTP/2 and HTTP/3 chart for some sites but think it's the right measure.