### PR TITLE
Stop a11yscore crashing on large lighthouse payloads

### DIFF
--- a/sql/timeseries/a11yScores.sql
+++ b/sql/timeseries/a11yScores.sql
@@ -22,7 +22,7 @@ FROM (
   SELECT
     SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
     IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-    IFNULL(CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS FLOAT64) * 100,getA11yScore(JSON_EXTRACT(report, '$.reportCategories'))) AS score
+    IFNULL(CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS FLOAT64) * 100, getA11yScore(JSON_EXTRACT(report, '$.reportCategories'))) AS score
   FROM
     `httparchive.lighthouse.*`
   WHERE

--- a/sql/timeseries/a11yScores.sql
+++ b/sql/timeseries/a11yScores.sql
@@ -1,4 +1,5 @@
 #standardSQL
+# Lighthouse changed format of scores in v3.0.0 released in July 2018 so hande old and new
 CREATE TEMPORARY FUNCTION getA11yScore(reportCategories STRING, score STRING)
 RETURNS FLOAT64
 LANGUAGE js AS """

--- a/sql/timeseries/a11yScores.sql
+++ b/sql/timeseries/a11yScores.sql
@@ -15,11 +15,11 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(11)], 2) AS p10,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(26)], 2) AS p25,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(51)], 2) AS p50,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(76)], 2) AS p75,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(91)], 2) AS p90
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(100)], 2) AS p10,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(250)], 2) AS p25,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(500)], 2) AS p50,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(750)], 2) AS p75,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(900)], 2) AS p90
 FROM
   `httparchive.lighthouse.*`
 WHERE

--- a/sql/timeseries/a11yScores.sql
+++ b/sql/timeseries/a11yScores.sql
@@ -1,12 +1,12 @@
 #standardSQL
-CREATE TEMPORARY FUNCTION getA11yScore(report STRING)
+CREATE TEMPORARY FUNCTION getA11yScore(reportCategories STRING, score STRING)
 RETURNS FLOAT64
 LANGUAGE js AS """
-  $=JSON.parse(report);
-  if ($.reportCategories) {
-    return $.reportCategories.find(i => i.name === 'Accessibility').score;
+  if (reportCategories) {
+    $=JSON.parse(reportCategories);
+    return $.find(i => i.name === 'Accessibility').score;
   } else {
-    return $.categories.accessibility.score * 100;
+    return score * 100;
   }
 """;
 
@@ -14,11 +14,11 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(APPROX_QUANTILES(getA11yScore(report), 101)[OFFSET(11)], 2) AS p10,
-  ROUND(APPROX_QUANTILES(getA11yScore(report), 101)[OFFSET(26)], 2) AS p25,
-  ROUND(APPROX_QUANTILES(getA11yScore(report), 101)[OFFSET(51)], 2) AS p50,
-  ROUND(APPROX_QUANTILES(getA11yScore(report), 101)[OFFSET(76)], 2) AS p75,
-  ROUND(APPROX_QUANTILES(getA11yScore(report), 101)[OFFSET(91)], 2) AS p90
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(11)], 2) AS p10,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(26)], 2) AS p25,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(51)], 2) AS p50,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(76)], 2) AS p75,
+  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 101)[OFFSET(91)], 2) AS p90
 FROM
   `httparchive.lighthouse.*`
 WHERE

--- a/sql/timeseries/a11yScores.sql
+++ b/sql/timeseries/a11yScores.sql
@@ -1,29 +1,33 @@
 #standardSQL
-# Lighthouse changed format of scores in v3.0.0 released in July 2018 so hande old and new
-CREATE TEMPORARY FUNCTION getA11yScore(reportCategories STRING, score STRING)
-RETURNS FLOAT64
+# Lighthouse changed format of scores in v3.0.0 released in July 2018 so handle old with a UDF
+CREATE TEMPORARY FUNCTION getA11yScore(reportCategories STRING)
+RETURNS FLOAT64 DETERMINISTIC
 LANGUAGE js AS """
-  if (reportCategories) {
-    $=JSON.parse(reportCategories);
+  $=JSON.parse(reportCategories);
+  if($) {
     return $.find(i => i.name === 'Accessibility').score;
-  } else {
-    return score * 100;
   }
 """;
 
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(100)], 2) AS p10,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(250)], 2) AS p25,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(500)], 2) AS p50,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(750)], 2) AS p75,
-  ROUND(APPROX_QUANTILES(getA11yScore(JSON_EXTRACT(report, '$.reportCategories'), JSON_EXTRACT(report, '$.categories.accessibility.score')), 1000)[OFFSET(900)], 2) AS p90
-FROM
-  `httparchive.lighthouse.*`
-WHERE
-  report IS NOT NULL
+  date,
+  UNIX_DATE(CAST(REPLACE(date, '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(100)], 2) AS p10,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(250)], 2) AS p25,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(500)], 2) AS p50,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(750)], 2) AS p75,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(900)], 2) AS p90
+FROM (
+  SELECT
+    SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+    IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+    IFNULL(CAST(JSON_EXTRACT(report, '$.categories.accessibility.score') AS FLOAT64) * 100,getA11yScore(JSON_EXTRACT(report, '$.reportCategories'))) AS score
+  FROM
+    `httparchive.lighthouse.*`
+  WHERE
+    report IS NOT NULL
+)
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/pwaScores.sql
+++ b/sql/timeseries/pwaScores.sql
@@ -1,7 +1,7 @@
 #standardSQL
 # Lighthouse changed format of scores in v3.0.0 released in July 2018 so handle old with a UDF
 CREATE TEMPORARY FUNCTION getPWAScore(reportCategories STRING)
-RETURNS FLOAT64
+RETURNS FLOAT64 DETERMINISTIC
 LANGUAGE js AS """
   $=JSON.parse(reportCategories);
   if ($) {

--- a/sql/timeseries/pwaScores.sql
+++ b/sql/timeseries/pwaScores.sql
@@ -22,7 +22,7 @@ FROM (
   SELECT
     SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
     IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-    IFNULL(CAST(JSON_EXTRACT(report, '$.categories.pwa.score') AS FLOAT64) * 100,getPWAScore(JSON_EXTRACT(report, '$.reportCategories'))) AS score
+    IFNULL(CAST(JSON_EXTRACT(report, '$.categories.pwa.score') AS FLOAT64) * 100, getPWAScore(JSON_EXTRACT(report, '$.reportCategories'))) AS score
   FROM
     `httparchive.lighthouse.*`
   WHERE

--- a/sql/timeseries/pwaScores.sql
+++ b/sql/timeseries/pwaScores.sql
@@ -1,30 +1,35 @@
 #standardSQL
-CREATE TEMPORARY FUNCTION getPWAScore(report STRING)
+# Lighthouse changed format of scores in v3.0.0 released in July 2018 so handle old with a UDF
+CREATE TEMPORARY FUNCTION getPWAScore(reportCategories STRING)
 RETURNS FLOAT64
 LANGUAGE js AS """
-  $=JSON.parse(report);
-  if ($.reportCategories) {
-    return $.reportCategories.find(i => i.name === 'Progressive Web App').score;
-  } else {
-    return $.categories.pwa.score * 100;
+  $=JSON.parse(reportCategories);
+  if ($) {
+    return $.find(i => i.name === 'Progressive Web App').score;
   }
 """;
 
 SELECT
-  SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
-  UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
-  IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(APPROX_QUANTILES(getPWAScore(report), 101)[OFFSET(11)], 2) AS p10,
-  ROUND(APPROX_QUANTILES(getPWAScore(report), 101)[OFFSET(26)], 2) AS p25,
-  ROUND(APPROX_QUANTILES(getPWAScore(report), 101)[OFFSET(51)], 2) AS p50,
-  ROUND(APPROX_QUANTILES(getPWAScore(report), 101)[OFFSET(76)], 2) AS p75,
-  ROUND(APPROX_QUANTILES(getPWAScore(report), 101)[OFFSET(91)], 2) AS p90
-FROM
-  `httparchive.lighthouse.*`
-WHERE
-  report IS NOT NULL
-  AND (JSON_EXTRACT(report, "$.audits.service-worker.score") = 'true'
-    OR JSON_EXTRACT(report, "$.audits.service-worker.score") = '1')
+  date,
+  UNIX_DATE(CAST(REPLACE(date, '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
+  client,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(100)], 2) AS p10,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(250)], 2) AS p25,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(500)], 2) AS p50,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(750)], 2) AS p75,
+  ROUND(APPROX_QUANTILES(score, 1000)[OFFSET(900)], 2) AS p90
+FROM (
+  SELECT
+    SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
+    IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
+    IFNULL(CAST(JSON_EXTRACT(report, '$.categories.pwa.score') AS FLOAT64) * 100,getPWAScore(JSON_EXTRACT(report, '$.reportCategories'))) AS score
+  FROM
+    `httparchive.lighthouse.*`
+  WHERE
+    report IS NOT NULL
+    AND (JSON_EXTRACT(report, "$.audits.service-worker.score") = 'true'
+         OR JSON_EXTRACT(report, "$.audits.service-worker.score") = '1')
+)
 GROUP BY
   date,
   timestamp,


### PR DESCRIPTION
Currently the [a11yscores.json](https://cdn.httparchive.org/reports/a11yScores.json) has not updated for May or June and is crashing out with the following:

```
Generating a11yScores timeseries
Waiting on bqjob_r6bfdf220e36ae1ab_0000017a6822c30c_1 ... (2277s) Current status: DONE   
BigQuery error in query operation: Error processing job 'httparchive:bqjob_r6bfdf220e36ae1ab_0000017a6822c30c_1': Resources exceeded during query execution: UDF out of memory.
```

This refactors the SQL to extract the relevant bits of JSON in SQL before sending to the JavaScript UDF so it doesn't need to parse the whole Lighthouse JSON object, which seems to solve the memory issue without having to exclude large payloads.

It seems to run considerably quicker (2 mins per month, instead of 12+ mins) — though still using the same amount of data so no cheaper. Guessing it's expensive to copy JSON from SQL world to JS world.

Tested on `2017_06_01_mobile` (old data format) and `2021_04_01_mobile` (last new data format that worked) and exact same results as were previously produced. Also it ran on `2021_05_01_mobile`, but when I tried old query on that month only it also succeeded 😢 So maybe only crashes on running whole dataset, so can't be 100% sure this fixes the crash without running that, but taking the speed increase as a good sign it will.