### PR TITLE
Fix incremental timeseries bug introduce with recent report changes

### DIFF
--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -192,8 +192,8 @@ else
 
 			if [[ -n "${date_join}" ]]; then
 				if [[ $(grep -i "WHERE" $query) ]]; then
-                    # If WHERE clause already exists then add to it, before GROUP BY
-					result=$(sed -e "s/\(GROUP BY\)/AND $date_join \1/" $query \
+                    # If WHERE clause already exists then add to it
+					result=$(sed -e "s/\(WHERE\)/\1 $date_join AND/" $query \
 						| sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/" \
 						| $BQ_CMD)
 				else


### PR DESCRIPTION
Changes in #114 added a subquery with a WHERE clause but no GROUP BY clause. This broke the logic used for incremental timeseries for those queries which assumed one or the other.

Noticed this while monitoring the magento June rerun.