### PR TITLE
Switch from rawValue to numericValue for three reports

### DIFF
--- a/sql/timeseries/bootupJs.sql
+++ b/sql/timeseries/bootupJs.sql
@@ -12,8 +12,8 @@ FROM (
   SELECT
     _TABLE_SUFFIX AS _TABLE_SUFFIX,
     CAST(IFNULL(
-      JSON_EXTRACT(report, "$.audits.bootup-time.rawValue"),
-      JSON_EXTRACT(report, "$.audits.bootup-time.numericValue")
+      JSON_EXTRACT(report, "$.audits.bootup-time.numericValue"),
+      JSON_EXTRACT(report, "$.audits.bootup-time.rawValue")
       ) AS FLOAT64) / 1000 AS value
   FROM
     `httparchive.lighthouse.*`

--- a/sql/timeseries/bootupJs.sql
+++ b/sql/timeseries/bootupJs.sql
@@ -3,13 +3,21 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(APPROX_QUANTILES(CAST(JSON_EXTRACT(report, "$.audits.bootup-time.rawValue") AS FLOAT64), 1001)[OFFSET(101)] / 1000, 2) AS p10,
-  ROUND(APPROX_QUANTILES(CAST(JSON_EXTRACT(report, "$.audits.bootup-time.rawValue") AS FLOAT64), 1001)[OFFSET(251)] / 1000, 2) AS p25,
-  ROUND(APPROX_QUANTILES(CAST(JSON_EXTRACT(report, "$.audits.bootup-time.rawValue") AS FLOAT64), 1001)[OFFSET(501)] / 1000, 2) AS p50,
-  ROUND(APPROX_QUANTILES(CAST(JSON_EXTRACT(report, "$.audits.bootup-time.rawValue") AS FLOAT64), 1001)[OFFSET(751)] / 1000, 2) AS p75,
-  ROUND(APPROX_QUANTILES(CAST(JSON_EXTRACT(report, "$.audits.bootup-time.rawValue") AS FLOAT64), 1001)[OFFSET(901)] / 1000, 2) AS p90
-FROM
-  `httparchive.lighthouse.*`
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(100)], 2) AS p10,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(250)], 2) AS p25,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(500)], 2) AS p50,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(750)], 2) AS p75,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(900)], 2) AS p90
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS _TABLE_SUFFIX,
+    CAST(IFNULL(
+      JSON_EXTRACT(report, "$.audits.bootup-time.rawValue"),
+      JSON_EXTRACT(report, "$.audits.bootup-time.numericValue")
+      ) AS FLOAT64) / 1000 AS value
+  FROM
+    `httparchive.lighthouse.*`
+)
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/ttci.sql
+++ b/sql/timeseries/ttci.sql
@@ -3,13 +3,24 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.consistently-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.interactive.rawValue")) AS FLOAT64), 1001)[OFFSET(101)] / 1000, 2) AS p10,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.consistently-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.interactive.rawValue")) AS FLOAT64), 1001)[OFFSET(251)] / 1000, 2) AS p25,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.consistently-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.interactive.rawValue")) AS FLOAT64), 1001)[OFFSET(501)] / 1000, 2) AS p50,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.consistently-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.interactive.rawValue")) AS FLOAT64), 1001)[OFFSET(751)] / 1000, 2) AS p75,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.consistently-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.interactive.rawValue")) AS FLOAT64), 1001)[OFFSET(901)] / 1000, 2) AS p90
-FROM
-  `httparchive.lighthouse.*`
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(100)], 2) AS p10,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(250)], 2) AS p25,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(500)], 2) AS p50,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(750)], 2) AS p75,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(900)], 2) AS p90
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS _TABLE_SUFFIX,
+    CAST(IFNULL(
+      JSON_EXTRACT(report, "$.audits.interactive.numericValue"),
+      IFNULL(
+        JSON_EXTRACT(report, "$.audits.interactive.rawValue"),
+        JSON_EXTRACT(report, "$.audits.consistently-interactive.rawValue")
+        )
+      ) AS FLOAT64) / 1000 AS value
+  FROM
+    `httparchive.lighthouse.*`
+)
 GROUP BY
   date,
   timestamp,
@@ -17,3 +28,4 @@ GROUP BY
 ORDER BY
   date DESC,
   client
+

--- a/sql/timeseries/ttfi.sql
+++ b/sql/timeseries/ttfi.sql
@@ -3,13 +3,24 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.first-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.first-cpu-idle.rawValue")) AS FLOAT64), 1001)[OFFSET(101)] / 1000, 2) AS p10,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.first-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.first-cpu-idle.rawValue")) AS FLOAT64), 1001)[OFFSET(251)] / 1000, 2) AS p25,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.first-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.first-cpu-idle.rawValue")) AS FLOAT64), 1001)[OFFSET(501)] / 1000, 2) AS p50,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.first-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.first-cpu-idle.rawValue")) AS FLOAT64), 1001)[OFFSET(751)] / 1000, 2) AS p75,
-  ROUND(APPROX_QUANTILES(CAST(IFNULL(JSON_EXTRACT(report, "$.audits.first-interactive.rawValue"), JSON_EXTRACT(report, "$.audits.first-cpu-idle.rawValue")) AS FLOAT64), 1001)[OFFSET(901)] / 1000, 2) AS p90
-FROM
-  `httparchive.lighthouse.*`
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(100)], 2) AS p10,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(250)], 2) AS p25,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(500)], 2) AS p50,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(750)], 2) AS p75,
+  ROUND(APPROX_QUANTILES(value, 1000)[OFFSET(900)], 2) AS p90
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS _TABLE_SUFFIX,
+    CAST(IFNULL(
+      JSON_EXTRACT(report, "$.audits.first-cpu-idle.numericValue"),
+      IFNULL(
+        JSON_EXTRACT(report, "$.audits.first-cpu-idle.rawValue"),
+        JSON_EXTRACT(report, "$.audits.first-interactive.rawValue")
+        )
+      ) AS FLOAT64) / 1000 AS value
+  FROM
+    `httparchive.lighthouse.*`
+)
 GROUP BY
   date,
   timestamp,
@@ -17,3 +28,4 @@ GROUP BY
 ORDER BY
   date DESC,
   client
+


### PR DESCRIPTION
Lighthouse switched from `rawValue` to `numericValue` a while back and we have three queries that have been returning null since:

- https://cdn.httparchive.org/reports/bootupJs.json
- https://cdn.httparchive.org/reports/ttfi.json
- https://cdn.httparchive.org/reports/ttci.json

Fixes https://github.com/HTTPArchive/httparchive.org/issues/213