### PR TITLE
Fix response_bodies pipeline

### DIFF
--- a/dataflow/python/.gitignore
+++ b/dataflow/python/.gitignore
@@ -2,3 +2,5 @@ env
 lib
 adblock.egg*
 local
+credentials/auth.json
+__pycache__

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -44,8 +44,7 @@ python bigquery_import.py \
   --region=us-west1 \
   --machine_type=n1-standard-32 \
   --input=android-Dec_1_2020 \
-  --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink
+  --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd
   ```
 
   The `--runner=DataflowRunner` option forces the pipeline to run in the cloud using Dataflow. To run locally, omit this option. Be aware that crawls consume TB of disk space, so only run locally using subsetted input datasets. To create a subset dataset, copy a few HAR files on GCS to a new directory.

--- a/dataflow/python/README.md
+++ b/dataflow/python/README.md
@@ -1,0 +1,23 @@
+# HTTP Archive Python Dataflow
+
+## Installation
+
+Follow the [Quickstart using Python](https://cloud.google.com/dataflow/docs/quickstarts/quickstart-python#before-you-begin) guide.
+
+1. Create a Python 3 `virtualenv`:
+
+  ```
+  python -m virtualenv --python=python3 --clear env
+  ```
+
+2. Install dependencies:
+
+  ```
+  pip install -r requirements.txt
+  ```
+
+3. Create a service account key, save it to `credentials/cert.json`, and set the environment variable:
+
+	```
+	export GOOGLE_APPLICATION_CREDENTIALS="./credentials/auth.json"
+	```

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A word-counting workflow."""
+
+# pytype: skip-file
+
+from __future__ import absolute_import
+
+import argparse
+import logging
+
+import apache_beam as beam
+from apache_beam.io.gcp.internal.clients import bigquery
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+
+
+def do_bigquery_import(har_file):
+  """Workflow to extract BigQuery data from HAR file."""
+
+  return (har_file | 'ExtractHAR' >> beam.Map(lambda har: har_file))
+
+
+def run(argv=None):
+  """Constructs and runs the BigQuery import pipeline."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--input',
+      required=True,
+      help='Input Cloud Storage directory to process.')
+  known_args, pipeline_args = parser.parse_known_args(argv)
+
+
+  with beam.Pipeline(argv=pipeline_args) as p:
+
+    table_spec = bigquery.TableReference(
+      projectId='httparchive',
+      datasetId='scratchspace',
+      tableId='dataflow_test')
+
+    table_schema = 'har:STRING'
+
+    (p 
+      | 'read' >> beam.io.ReadFromText(known_args.input)
+      | 'BigQueryImport' >> beam.io.WriteToBigQuery(
+        table_spec,
+        schema=table_schema,
+        write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+        create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  run()

--- a/dataflow/python/requirements.txt
+++ b/dataflow/python/requirements.txt
@@ -1,0 +1,1 @@
+apache-beam[gcp]

--- a/dataflow/python/requirements.txt
+++ b/dataflow/python/requirements.txt
@@ -1,1 +1,1 @@
-apache-beam[gcp]==2.26
+apache-beam[gcp]==2.31

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -7,6 +7,5 @@ python bigquery_import.py \
   --staging_location=gs://httparchive/dataflow/staging \
   --region=us-west1 \
   --machine_type=n1-standard-32 \
-  --input=chrome-Nov_1_2020 \
-  --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd \
-  --experiment=use_beam_bq_sink
+  --input=android-Jul_1_2021 \
+  --worker_disk_type=compute.googleapis.com/projects//zones//diskTypes/pd-ssd

--- a/dataflow/python/run.sh
+++ b/dataflow/python/run.sh
@@ -1,0 +1,4 @@
+python bigquery_import.py \
+	--project=httparchive \
+	--stagingLocation=gs://httparchive/dataflow/staging \
+	--input gs://httparchive/chrome-Mar_24_2020/


### PR DESCRIPTION
To get around the 15 TB limitation of Dataflow, load the `response_bodies` tables in halves.

This change also upgrades to Apache Beam 2.31 and removes the old experimental `use_beam_bq_sink` flag.

Tested successfully on 2021_07_01 for both desktop and mobile.