### PR TITLE
Omit null response bodies

### DIFF
--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -160,7 +160,10 @@ def get_response_bodies(har):
 
   for request in requests:
     request_url = request.get('_full_url')
-    body = request.get('response').get('content').get('text', '')
+    body = request.get('response').get('content').get('text', None)
+
+    if body == None:
+      continue
 
     truncated = len(body) > MAX_CONTENT_SIZE
     if truncated:


### PR DESCRIPTION
Successfully tested on the November 1, 2020 mobile table:

![image](https://user-images.githubusercontent.com/1120896/127801076-0d7c1ee6-4f67-49af-9693-38b1e2a66674.png)

Fixes #124