### PR TITLE
Query running improvements

### DIFF
--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -30,7 +30,7 @@ REPORTS="*"
 VERBOSE=0
 
 # Read the flags.
-while getopts ":fth:l:r:" opt; do
+while getopts ":ftvh:l:r:" opt; do
 	case "${opt}" in
 		h)
 			GENERATE_HISTOGRAM=1
@@ -143,7 +143,7 @@ else
 
 		# Run the histogram query on BigQuery.
 		START_TIME=$SECONDS
-		result=$(cat $QUERY | $BQ_CMD)
+		result=$(cat $query | $BQ_CMD)
 
 		# Make sure the query succeeded.
 		if [ $? -eq 0 ]; then
@@ -309,7 +309,7 @@ else
 
 		# Run the timeseries query on BigQuery.
 		START_TIME=$SECONDS
-		result=$(cat $QUERY | $BQ_CMD)
+		result=$(cat $query | $BQ_CMD)
 
 		# Make sure the query succeeded.
 		if [ $? -eq 0 ]; then

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -138,7 +138,7 @@ else
 
 		if [ ${VERBOSE} -eq 1 ]; then
 			echo "Running this query:"
-			printf "${sql}"
+			printf "${sql}\n"
 		fi
 
 		# Run the histogram query on BigQuery.
@@ -304,7 +304,7 @@ else
 
 		if [ ${VERBOSE} -eq 1 ]; then
 			echo "Running this query:"
-			printf "${sql}"
+			printf "${sql}\n"
 		fi
 
 		# Run the timeseries query on BigQuery.

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -91,6 +91,12 @@ else
 
 	# Run all histogram queries.
 	for query in sql/histograms/$REPORTS.sql; do
+
+		if [[ -z $query ]]; then
+			echo "Nothing to do"
+			continue;
+		fi
+
 		# Extract the metric name from the file path.
 		# For example, `sql/histograms/foo.sql` will produce `foo`.
 		metric=$(echo $(basename $query) | cut -d"." -f1)
@@ -163,6 +169,12 @@ else
 
 	# Run all timeseries queries.
 	for query in sql/timeseries/$REPORTS.sql; do
+
+		if [[ -z $query ]]; then
+			echo "Nothing to do"
+			continue;
+		fi
+
 		# Extract the metric name from the file path.
 		metric=$(echo $(basename $query) | cut -d"." -f1)
 
@@ -279,7 +291,7 @@ else
 			fi
 
 		else
-			if [[ -n "${date_join}" ]];
+			if [[ -n "${date_join}" ]]; then
 				if [[ $(grep -i "WHERE" $query) ]]; then
 					# If WHERE clause already exists then add to it, before GROUP BY
 					query=$(sed -e "s/\(WHERE\)/\1 $date_join AND /" $query)

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -143,7 +143,7 @@ else
 
 		# Run the histogram query on BigQuery.
 		START_TIME=$SECONDS
-		result=$(echo "${sql}" | $BQ_CMD)
+		result=$(printf "${sql}" | $BQ_CMD)
 
 		# Make sure the query succeeded.
 		if [ $? -eq 0 ]; then
@@ -309,7 +309,7 @@ else
 
 		# Run the timeseries query on BigQuery.
 		START_TIME=$SECONDS
-		result=$(echo "${sql}" | $BQ_CMD)
+		result=$(printf "${sql}" | $BQ_CMD)
 
 		# Make sure the query succeeded.
 		if [ $? -eq 0 ]; then

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -99,7 +99,7 @@ else
 		gsutil ls $gs_url &> /dev/null
 		if [ $? -eq 0 ] && [ $FORCE -eq 0 ]; then
 			# The file already exists, so skip the query.
-			echo -e "Skipping $metric histogram"
+			echo -e "Skipping $metric histogram as already exists"
 			continue
 		fi
 
@@ -279,14 +279,14 @@ else
 			fi
 
 		else
-			if [[ -z "${date_join}" ]]; then
-				# Leave query as it is
-			elif [[ $(grep -i "WHERE" $query) ]]; then
-				# If WHERE clause already exists then add to it, before GROUP BY
-				query=$(sed -e "s/\(WHERE\)/\1 $date_join AND /" $query)
-			else
-				# If WHERE clause doesn't exists then add it, before GROUP BY
-				query=$(sed -e "s/\(GROUP BY\)/WHERE $date_join \1/" $query)
+			if [[ -n "${date_join}" ]];
+				if [[ $(grep -i "WHERE" $query) ]]; then
+					# If WHERE clause already exists then add to it, before GROUP BY
+					query=$(sed -e "s/\(WHERE\)/\1 $date_join AND /" $query)
+				else
+					# If WHERE clause doesn't exists then add it, before GROUP BY
+					query=$(sed -e "s/\(GROUP BY\)/WHERE $date_join \1/" $query)
+				fi
 			fi
 		fi
 

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -92,7 +92,7 @@ else
 	# Run all histogram queries.
 	for query in sql/histograms/$REPORTS.sql; do
 
-		if [[ -z $query ]]; then
+		if [[ ! -f $query ]]; then
 			echo "Nothing to do"
 			continue;
 		fi
@@ -170,7 +170,7 @@ else
 	# Run all timeseries queries.
 	for query in sql/timeseries/$REPORTS.sql; do
 
-		if [[ -z $query ]]; then
+		if [[ ! -f $query ]]; then
 			echo "Nothing to do"
 			continue;
 		fi

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -27,6 +27,7 @@ GENERATE_HISTOGRAM=0
 GENERATE_TIMESERIES=0
 LENS=""
 REPORTS="*"
+VERBOSE=0
 
 # Read the flags.
 while getopts ":fth:l:r:" opt; do
@@ -39,6 +40,9 @@ while getopts ":fth:l:r:" opt; do
 			;;
 		t)
 			GENERATE_TIMESERIES=1
+			;;
+		v)
+			VERBOSE=1
 			;;
 		f)
 			FORCE=1
@@ -102,8 +106,6 @@ else
 		echo -e "Generating $metric histogram"
 
 		# Replace the date template in the query.
-		# Run the query on BigQuery.
-		START_TIME=$SECONDS
 		if [[ $LENS != "" ]]; then
 			lens_join="JOIN ($(cat sql/lens/$LENS/histograms.sql | tr '\n' ' ')) USING (url, _TABLE_SUFFIX)"
 			if [[ $metric == crux* ]]; then
@@ -115,21 +117,28 @@ else
 					continue
 				fi
 
-				result=$(sed -e "s/\(\`chrome-ux-report[^\`]*\`\)/\1 $lens_join/" $query \
+				query=$(sed -e "s/\(\`chrome-ux-report[^\`]*\`\)/\1 $lens_join/" $query \
 					| sed -e "s/\${YYYY_MM_DD}/$YYYY_MM_DD/g" \
-					| sed -e "s/\${YYYYMM}/$YYYYMM/g" \
-					| $BQ_CMD)
+					| sed -e "s/\${YYYYMM}/$YYYYMM/g")
 			else
-				result=$(sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/" $query \
+				query=$(sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/" $query \
 					| sed -e "s/\${YYYY_MM_DD}/$YYYY_MM_DD/g" \
-					| sed -e "s/\${YYYYMM}/$YYYYMM/g" \
-					| $BQ_CMD)
+					| sed -e "s/\${YYYYMM}/$YYYYMM/g")
 			fi
 		else
-			result=$(sed -e "s/\${YYYY_MM_DD}/$YYYY_MM_DD/" $query \
-				| sed -e "s/\${YYYYMM}/$YYYYMM/" \
-				| $BQ_CMD)
+			query=$(sed -e "s/\${YYYY_MM_DD}/$YYYY_MM_DD/" $query \
+				| sed -e "s/\${YYYYMM}/$YYYYMM/")
 		fi
+
+		if [ ${VERBOSE} -eq 1 ]; then
+			echo "Running this query:"
+			echo $query
+		fi
+
+		# Run the histogram query on BigQuery.
+		START_TIME=$SECONDS
+		result=$(cat $QUERY | $BQ_CMD)
+
 		# Make sure the query succeeded.
 		if [ $? -eq 0 ]; then
 			ELAPSED_TIME=$(($SECONDS - $START_TIME))
@@ -189,6 +198,9 @@ else
 							date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
 						fi
 					fi
+
+					echo -e "Generating $metric timeseries in incremental mode from ${max_date} to ${YYYY_MM_DD}"
+
 				else
 					echo -e "Skipping $metric timeseries as ${YYYY_MM_DD} already exists in the data. Run in force mode (-f) if you want to rerun."
 					continue
@@ -204,6 +216,8 @@ else
 					# If a date is given, then only run up until then (in case next month is mid run as don't wanna get just desktop data)
 					date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
 				fi
+
+				echo -e "Force Mode=${FORCE}. Generating $metric timeseries from start until ${YYYY_MM_DD}."
 			fi
 		elif [[ -n "$YYYY_MM_DD" ]]; then
 			# Even if the file doesn't exist we only wanna run up until date given in case next month is mid-run as don't wanna get just desktop data
@@ -214,18 +228,13 @@ else
 			elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
 				date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
 			fi
-		fi
 
-		if [[ -n "${date_join}" && -n "${max_date}" ]]; then
-			echo -e "Generating $metric timeseries in incremental mode from ${max_date} to ${YYYY_MM_DD}"
-		elif [[ -n "${date_join}" ]]; then
-			echo -e "Generating $metric timeseries from start until ${YYYY_MM_DD}"
+			echo -e "Timeseries does not exist. Generating $metric timeseries from start until ${YYYY_MM_DD}"
+
 		else
-			echo -e "Generating $metric timeseries from start"
+			echo -e "Timeseries does not exist. Generating $metric timeseries from start"
 		fi
 
-		# Run the query on BigQuery.
-		START_TIME=$SECONDS
 		if [[ $LENS != "" ]]; then
 
 			if [[ $(grep "httparchive.blink_features.usage" $query) ]]; then
@@ -236,13 +245,11 @@ else
 
 					# For blink features for lenses we have a BLINK_DATE_JOIN variable to replace
 					if [[ -z "${date_join}" ]]; then
-						result=$(sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
-						| sed -e "s/ {{ BLINK_DATE_JOIN }}//g" \
-						| $BQ_CMD)
+						query=$(sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
+						| sed -e "s/ {{ BLINK_DATE_JOIN }}//g")
 					else
-						result=$( sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
-							| sed -e "s/{{ BLINK_DATE_JOIN }}/AND $date_join/g" \
-							| $BQ_CMD)
+						query=$( sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
+							| sed -e "s/{{ BLINK_DATE_JOIN }}/AND $date_join/g")
 					fi
 				else
 					echo "blink_features.usage queries not supported for this lens so skipping lens"
@@ -259,36 +266,38 @@ else
 				if [[ -n "${date_join}" ]]; then
 					if [[ $(grep -i "WHERE" $query) ]]; then
 						# If WHERE clause already exists then add to it, before GROUP BY
-						result=$(sed -e "s/\(WHERE\)/\1 $date_join AND/" $query \
-							| sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/" \
-							| $BQ_CMD)
+						query=$(sed -e "s/\(WHERE\)/\1 $date_join AND/" $query \
+							| sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/")
 					else
 						# If WHERE clause doesn't exists then add it, before GROUP BY
-						result=$(sed -e "s/\(GROUP BY\)/WHERE $date_join \1/" $query \
-							| sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/" \
-							| $BQ_CMD)
+						query=$(sed -e "s/\(GROUP BY\)/WHERE $date_join \1/" $query \
+							| sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/")
 					fi
 				else
-					result=$(sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/" $query \
-						| $BQ_CMD)
+					query=$(sed -e "s/\(\`[^\`]*\`)*\)/\1 $lens_join/" $query)
 				fi
 			fi
 
 		else
 			if [[ -z "${date_join}" ]]; then
-				date_join=""
-				result=$(cat $query \
-					| $BQ_CMD)
+				# Leave query as it is
 			elif [[ $(grep -i "WHERE" $query) ]]; then
 				# If WHERE clause already exists then add to it, before GROUP BY
-				result=$(sed -e "s/\(WHERE\)/\1 $date_join AND /" $query \
-					| $BQ_CMD)
+				query=$(sed -e "s/\(WHERE\)/\1 $date_join AND /" $query)
 			else
 				# If WHERE clause doesn't exists then add it, before GROUP BY
-				result=$(sed -e "s/\(GROUP BY\)/WHERE $date_join \1/" $query \
-					| $BQ_CMD)
+				query=$(sed -e "s/\(GROUP BY\)/WHERE $date_join \1/" $query)
 			fi
 		fi
+
+		if [ ${VERBOSE} -eq 1 ]; then
+			echo "Running this query:"
+			echo $query
+		fi
+
+		# Run the timeseries query on BigQuery.
+		START_TIME=$SECONDS
+		result=$(cat $QUERY | $BQ_CMD)
 
 		# Make sure the query succeeded.
 		if [ $? -eq 0 ]; then

--- a/sql/timeseries/h2.sql
+++ b/sql/timeseries/h2.sql
@@ -5,16 +5,7 @@ SELECT
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
   ROUND(SUM(IF(protocol = 'HTTP/2', 1, 0)) * 100 / COUNT(0), 2) AS percent
 FROM
-  (
-    SELECT
-      page AS url,
-      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol,
-      _TABLE_SUFFIX AS _TABLE_SUFFIX
-    FROM
-      `httparchive.requests.*`
-    WHERE
-      1=1 /* Dummy WHERE clause to allow date joins on this subquery for cost/time savings */
-  )
+  (SELECT page AS url, JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol, _TABLE_SUFFIX AS _TABLE_SUFFIX FROM `httparchive.requests.*`)
 GROUP BY
   date,
   timestamp,

--- a/sql/timeseries/h2.sql
+++ b/sql/timeseries/h2.sql
@@ -13,7 +13,7 @@ FROM
     FROM
       `httparchive.requests.*`
     WHERE
-      1=1 /* Dummy join to allow date joins on this subquery for cost/time savings */
+      1=1 /* Dummy WHERE clause to allow date joins on this subquery for cost/time savings */
   )
 GROUP BY
   date,

--- a/sql/timeseries/h2.sql
+++ b/sql/timeseries/h2.sql
@@ -5,7 +5,16 @@ SELECT
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
   ROUND(SUM(IF(protocol = 'HTTP/2', 1, 0)) * 100 / COUNT(0), 2) AS percent
 FROM
-  (SELECT page AS url, JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol, _TABLE_SUFFIX AS _TABLE_SUFFIX FROM `httparchive.requests.*`)
+  (
+    SELECT
+      page AS url,
+      JSON_EXTRACT_SCALAR(payload, '$._protocol') AS protocol,
+      _TABLE_SUFFIX AS _TABLE_SUFFIX
+    FROM
+      `httparchive.requests.*`
+    WHERE
+      1=1 /* Dummy join to allow date joins on this subquery for cost/time savings */
+  )
 GROUP BY
   date,
   timestamp,


### PR DESCRIPTION
Makes the following changes:
- Adds the SQL to a `$sql` variable rather than running immediately
- Moves the run command to the end based on the `$sql` variable
- Add Verbose option to print the SQL
- Handles missing reports better (less error messages for globs which don't match)
- Improves messages to accurately state whether date ranges are being used or not (previously said date ranges were used even in Force mode).
- Show if force mode is being used.
