### PR TITLE
Crux and blink for other lenses

### DIFF
--- a/sql/.sqlfluffignore
+++ b/sql/.sqlfluffignore
@@ -1,2 +1,1 @@
-/lens/top1*/crux_histograms.sql
-
+/lens/*/crux_histograms.sql

--- a/sql/lens/drupal/blink_timeseries.sql
+++ b/sql/lens/drupal/blink_timeseries.sql
@@ -12,7 +12,7 @@ FROM
 JOIN
   (
     SELECT
-      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      _TABLE_SUFFIX AS _TABLE_SUFFIX,
       url AS tech_url
     FROM
       `httparchive.technologies.*`
@@ -30,18 +30,18 @@ JOIN (
     COUNT(DISTINCT url) AS total
   FROM `httparchive.blink_features.features`
   JOIN
-  (
-    SELECT
-      _TABLE_SUFFIX as _TABLE_SUFFIX,
-      url AS tech_url
-    FROM
-      `httparchive.technologies.*`
-    WHERE
-      app = 'Drupal'
-    GROUP BY
-      1,
-      2
-  )
+    (
+      SELECT
+        _TABLE_SUFFIX AS _TABLE_SUFFIX,
+        url AS tech_url
+      FROM
+        `httparchive.technologies.*`
+      WHERE
+        app = 'Drupal'
+      GROUP BY
+        1,
+        2
+    )
   ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
   WHERE 1 = 1
 {{ BLINK_DATE_JOIN }}

--- a/sql/lens/drupal/blink_timeseries.sql
+++ b/sql/lens/drupal/blink_timeseries.sql
@@ -1,0 +1,72 @@
+SELECT
+  REGEXP_REPLACE(CAST(yyyymmdd AS STRING), '-', '') AS yyyymmdd,
+  client,
+  id,
+  feature,
+  type,
+  COUNT(0) AS num_urls,
+  MAX(total) AS total_urls,
+  SAFE_DIVIDE(COUNT(0), max(total)) AS num_urls_pct
+FROM
+  `httparchive.blink_features.features`
+JOIN
+  (
+    SELECT
+      PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
+      SUBSTR(_TABLE_SUFFIX, 12) AS client,
+      url
+    FROM
+      `httparchive.technologies.*`
+    WHERE
+      app = 'Drupal' AND
+      LENGTH(url) > 0
+    GROUP BY
+      1,
+      2,
+      3
+  )
+USING (yyyymmdd, url, client)
+JOIN (
+  SELECT
+    yyyymmdd,
+    client,
+    COUNT(DISTINCT url) AS total
+  FROM `httparchive.blink_features.features`
+  JOIN
+    (
+      SELECT
+        PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
+        SUBSTR(_TABLE_SUFFIX, 12) AS client,
+        url
+      FROM
+        `httparchive.technologies.*`
+      WHERE
+        app = 'Drupal' AND
+        LENGTH(url) > 0
+      GROUP BY
+        1,
+        2,
+        3
+    )
+  USING (yyyymmdd, url, client)
+  WHERE 1 = 1
+{{ BLINK_DATE_JOIN }}
+  GROUP BY
+    yyyymmdd,
+    client
+  )
+USING (yyyymmdd, client)
+WHERE 1 = 1
+{{ BLINK_DATE_JOIN }}
+GROUP BY
+  yyyymmdd,
+  client,
+  id,
+  feature,
+  type
+ORDER BY
+  yyyymmdd,
+  client,
+  id,
+  feature,
+  type

--- a/sql/lens/drupal/blink_timeseries.sql
+++ b/sql/lens/drupal/blink_timeseries.sql
@@ -12,20 +12,17 @@ FROM
 JOIN
   (
     SELECT
-      PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
-      SUBSTR(_TABLE_SUFFIX, 12) AS client,
-      url
+      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      url AS tech_url
     FROM
       `httparchive.technologies.*`
     WHERE
-      app = 'Drupal' AND
-      LENGTH(url) > 0
+      app = 'Drupal'
     GROUP BY
       1,
-      2,
-      3
+      2
   )
-USING (yyyymmdd, url, client)
+ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
 JOIN (
   SELECT
     yyyymmdd,
@@ -33,22 +30,19 @@ JOIN (
     COUNT(DISTINCT url) AS total
   FROM `httparchive.blink_features.features`
   JOIN
-    (
-      SELECT
-        PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
-        SUBSTR(_TABLE_SUFFIX, 12) AS client,
-        url
-      FROM
-        `httparchive.technologies.*`
-      WHERE
-        app = 'Drupal' AND
-        LENGTH(url) > 0
-      GROUP BY
-        1,
-        2,
-        3
-    )
-  USING (yyyymmdd, url, client)
+  (
+    SELECT
+      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      url AS tech_url
+    FROM
+      `httparchive.technologies.*`
+    WHERE
+      app = 'Drupal'
+    GROUP BY
+      1,
+      2
+  )
+  ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
   WHERE 1 = 1
 {{ BLINK_DATE_JOIN }}
   GROUP BY

--- a/sql/lens/drupal/crux_histograms.sql
+++ b/sql/lens/drupal/crux_histograms.sql
@@ -1,0 +1,15 @@
+JOIN
+  (
+  SELECT
+    url,
+    _TABLE_SUFFIX AS _TABLE_SUFFIX
+  FROM
+    `httparchive.technologies.${YYYY_MM_DD}_*`
+  WHERE
+    app = 'Drupal' and
+    LENGTH(url) > 0
+  GROUP BY
+    1,
+    2
+  )
+ON (SUBSTR(url, 0, LENGTH(url) -1) = origin AND form_factor.name = IF(_TABLE_SUFFIX = 'desktop', 'desktop', 'phone'))

--- a/sql/lens/magento/blink_timeseries.sql
+++ b/sql/lens/magento/blink_timeseries.sql
@@ -1,0 +1,72 @@
+SELECT
+  REGEXP_REPLACE(CAST(yyyymmdd AS STRING), '-', '') AS yyyymmdd,
+  client,
+  id,
+  feature,
+  type,
+  COUNT(0) AS num_urls,
+  MAX(total) AS total_urls,
+  SAFE_DIVIDE(COUNT(0), max(total)) AS num_urls_pct
+FROM
+  `httparchive.blink_features.features`
+JOIN
+  (
+    SELECT
+      PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
+      SUBSTR(_TABLE_SUFFIX, 12) AS client,
+      url
+    FROM
+      `httparchive.technologies.*`
+    WHERE
+      app = 'Magento' AND
+      LENGTH(url) > 0
+    GROUP BY
+      1,
+      2,
+      3
+  )
+USING (yyyymmdd, url, client)
+JOIN (
+  SELECT
+    yyyymmdd,
+    client,
+    COUNT(DISTINCT url) AS total
+  FROM `httparchive.blink_features.features`
+  JOIN
+    (
+      SELECT
+        PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
+        SUBSTR(_TABLE_SUFFIX, 12) AS client,
+        url
+      FROM
+        `httparchive.technologies.*`
+      WHERE
+        app = 'Magento' AND
+        LENGTH(url) > 0
+      GROUP BY
+        1,
+        2,
+        3
+    )
+  USING (yyyymmdd, url, client)
+  WHERE 1 = 1
+{{ BLINK_DATE_JOIN }}
+  GROUP BY
+    yyyymmdd,
+    client
+  )
+USING (yyyymmdd, client)
+WHERE 1 = 1
+{{ BLINK_DATE_JOIN }}
+GROUP BY
+  yyyymmdd,
+  client,
+  id,
+  feature,
+  type
+ORDER BY
+  yyyymmdd,
+  client,
+  id,
+  feature,
+  type

--- a/sql/lens/magento/blink_timeseries.sql
+++ b/sql/lens/magento/blink_timeseries.sql
@@ -12,7 +12,7 @@ FROM
 JOIN
   (
     SELECT
-      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      _TABLE_SUFFIX AS _TABLE_SUFFIX,
       url AS tech_url
     FROM
       `httparchive.technologies.*`
@@ -30,18 +30,18 @@ JOIN (
     COUNT(DISTINCT url) AS total
   FROM `httparchive.blink_features.features`
   JOIN
-  (
-    SELECT
-      _TABLE_SUFFIX as _TABLE_SUFFIX,
-      url AS tech_url
-    FROM
-      `httparchive.technologies.*`
-    WHERE
-      app = 'Magento'
-    GROUP BY
-      1,
-      2
-  )
+    (
+      SELECT
+        _TABLE_SUFFIX AS _TABLE_SUFFIX,
+        url AS tech_url
+      FROM
+        `httparchive.technologies.*`
+      WHERE
+        app = 'Magento'
+      GROUP BY
+        1,
+        2
+    )
   ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
   WHERE 1 = 1
 {{ BLINK_DATE_JOIN }}

--- a/sql/lens/magento/blink_timeseries.sql
+++ b/sql/lens/magento/blink_timeseries.sql
@@ -12,20 +12,17 @@ FROM
 JOIN
   (
     SELECT
-      PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
-      SUBSTR(_TABLE_SUFFIX, 12) AS client,
-      url
+      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      url AS tech_url
     FROM
       `httparchive.technologies.*`
     WHERE
-      app = 'Magento' AND
-      LENGTH(url) > 0
+      app = 'Magento'
     GROUP BY
       1,
-      2,
-      3
+      2
   )
-USING (yyyymmdd, url, client)
+ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
 JOIN (
   SELECT
     yyyymmdd,
@@ -33,22 +30,19 @@ JOIN (
     COUNT(DISTINCT url) AS total
   FROM `httparchive.blink_features.features`
   JOIN
-    (
-      SELECT
-        PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
-        SUBSTR(_TABLE_SUFFIX, 12) AS client,
-        url
-      FROM
-        `httparchive.technologies.*`
-      WHERE
-        app = 'Magento' AND
-        LENGTH(url) > 0
-      GROUP BY
-        1,
-        2,
-        3
-    )
-  USING (yyyymmdd, url, client)
+  (
+    SELECT
+      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      url AS tech_url
+    FROM
+      `httparchive.technologies.*`
+    WHERE
+      app = 'Magento'
+    GROUP BY
+      1,
+      2
+  )
+  ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
   WHERE 1 = 1
 {{ BLINK_DATE_JOIN }}
   GROUP BY

--- a/sql/lens/magento/crux_histograms.sql
+++ b/sql/lens/magento/crux_histograms.sql
@@ -1,0 +1,15 @@
+INNER JOIN
+  (
+  SELECT
+    url,
+    _TABLE_SUFFIX AS _TABLE_SUFFIX
+  FROM
+    `httparchive.technologies.${YYYY_MM_DD}_*`
+  WHERE
+    app = 'Magento' and
+    LENGTH(url) > 0
+  GROUP BY
+    1,
+    2
+  )
+ON (SUBSTR(url, 0, LENGTH(url) -1) = origin AND form_factor.name = IF(_TABLE_SUFFIX = 'desktop', 'desktop', 'phone'))

--- a/sql/lens/wordpress/blink_timeseries.sql
+++ b/sql/lens/wordpress/blink_timeseries.sql
@@ -12,20 +12,17 @@ FROM
 JOIN
   (
     SELECT
-      PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
-      SUBSTR(_TABLE_SUFFIX, 12) AS client,
-      url
+      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      url AS tech_url
     FROM
       `httparchive.technologies.*`
     WHERE
-      app = 'WordPress' AND
-      LENGTH(url) > 0
+      app = 'WordPress'
     GROUP BY
       1,
-      2,
-      3
+      2
   )
-USING (yyyymmdd, url, client)
+ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
 JOIN (
   SELECT
     yyyymmdd,
@@ -33,22 +30,19 @@ JOIN (
     COUNT(DISTINCT url) AS total
   FROM `httparchive.blink_features.features`
   JOIN
-    (
-      SELECT
-        PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
-        SUBSTR(_TABLE_SUFFIX, 12) AS client,
-        url
-      FROM
-        `httparchive.technologies.*`
-      WHERE
-        app = 'WordPress' AND
-        LENGTH(url) > 0
-      GROUP BY
-        1,
-        2,
-        3
-    )
-  USING (yyyymmdd, url, client)
+  (
+    SELECT
+      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      url AS tech_url
+    FROM
+      `httparchive.technologies.*`
+    WHERE
+      app = 'WordPress'
+    GROUP BY
+      1,
+      2
+  )
+  ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
   WHERE 1 = 1
 {{ BLINK_DATE_JOIN }}
   GROUP BY

--- a/sql/lens/wordpress/blink_timeseries.sql
+++ b/sql/lens/wordpress/blink_timeseries.sql
@@ -12,7 +12,7 @@ FROM
 JOIN
   (
     SELECT
-      _TABLE_SUFFIX as _TABLE_SUFFIX,
+      _TABLE_SUFFIX AS _TABLE_SUFFIX,
       url AS tech_url
     FROM
       `httparchive.technologies.*`
@@ -30,18 +30,18 @@ JOIN (
     COUNT(DISTINCT url) AS total
   FROM `httparchive.blink_features.features`
   JOIN
-  (
-    SELECT
-      _TABLE_SUFFIX as _TABLE_SUFFIX,
-      url AS tech_url
-    FROM
-      `httparchive.technologies.*`
-    WHERE
-      app = 'WordPress'
-    GROUP BY
-      1,
-      2
-  )
+    (
+      SELECT
+        _TABLE_SUFFIX AS _TABLE_SUFFIX,
+        url AS tech_url
+      FROM
+        `httparchive.technologies.*`
+      WHERE
+        app = 'WordPress'
+      GROUP BY
+        1,
+        2
+    )
   ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || "_" || client)
   WHERE 1 = 1
 {{ BLINK_DATE_JOIN }}

--- a/sql/lens/wordpress/blink_timeseries.sql
+++ b/sql/lens/wordpress/blink_timeseries.sql
@@ -1,0 +1,72 @@
+SELECT
+  REGEXP_REPLACE(CAST(yyyymmdd AS STRING), '-', '') AS yyyymmdd,
+  client,
+  id,
+  feature,
+  type,
+  COUNT(0) AS num_urls,
+  MAX(total) AS total_urls,
+  SAFE_DIVIDE(COUNT(0), max(total)) AS num_urls_pct
+FROM
+  `httparchive.blink_features.features`
+JOIN
+  (
+    SELECT
+      PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
+      SUBSTR(_TABLE_SUFFIX, 12) AS client,
+      url
+    FROM
+      `httparchive.technologies.*`
+    WHERE
+      app = 'WordPress' AND
+      LENGTH(url) > 0
+    GROUP BY
+      1,
+      2,
+      3
+  )
+USING (yyyymmdd, url, client)
+JOIN (
+  SELECT
+    yyyymmdd,
+    client,
+    COUNT(DISTINCT url) AS total
+  FROM `httparchive.blink_features.features`
+  JOIN
+    (
+      SELECT
+        PARSE_DATE('%Y_%m_%d', SUBSTR(_TABLE_SUFFIX, 0, 10)) AS yyyymmdd,
+        SUBSTR(_TABLE_SUFFIX, 12) AS client,
+        url
+      FROM
+        `httparchive.technologies.*`
+      WHERE
+        app = 'WordPress' AND
+        LENGTH(url) > 0
+      GROUP BY
+        1,
+        2,
+        3
+    )
+  USING (yyyymmdd, url, client)
+  WHERE 1 = 1
+{{ BLINK_DATE_JOIN }}
+  GROUP BY
+    yyyymmdd,
+    client
+  )
+USING (yyyymmdd, client)
+WHERE 1 = 1
+{{ BLINK_DATE_JOIN }}
+GROUP BY
+  yyyymmdd,
+  client,
+  id,
+  feature,
+  type
+ORDER BY
+  yyyymmdd,
+  client,
+  id,
+  feature,
+  type

--- a/sql/lens/wordpress/crux_histograms.sql
+++ b/sql/lens/wordpress/crux_histograms.sql
@@ -1,0 +1,15 @@
+INNER JOIN
+  (
+  SELECT
+    url,
+    _TABLE_SUFFIX AS _TABLE_SUFFIX
+  FROM
+    `httparchive.technologies.${YYYY_MM_DD}_*`
+  WHERE
+    app = 'WordPress' and
+    LENGTH(url) > 0
+  GROUP BY
+    1,
+    2
+  )
+ON (SUBSTR(url, 0, LENGTH(url) -1) = origin AND form_factor.name = IF(_TABLE_SUFFIX = 'desktop', 'desktop', 'phone'))


### PR DESCRIPTION
In #121 I added the Ranking lenses and also the ability to run the Blink timeseries queries, and CrUX histograms for them -which we couldn't previously do for the old lenses.

This PR adds the same for the old lenses (Drupal, Magento, and WordPress).

I've also rerun the historgrams for 20210801 (I decided against going back further since these aren't used that much to be honest so latest and go forward is sufficient IMHO), and the timeseries as part of testing.