### PR TITLE
Add script to allow you to delete one month stats

### DIFF
--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -96,11 +96,11 @@ for query in sql/timeseries/$REPORTS.sql; do
 				echo "${current_contents}\n"
 			fi
 
-			new_contents=$(echo "$current_contents" | jq -c --indent 1 --arg date "${YYYY_MM_DD}" '.[] | select(.date!=$data)' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
+			new_contents=$(echo "$current_contents" | jq -c --indent 1 --arg date "${YYYY_MM_DD}" '.[] | select(.date!=$date)' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
 
 			if [ ${VERBOSE} -eq 1 ]; then
 				echo "New JSON:"
-				echo "${new_contents}\n"
+				echo "${new_contents}"
 			fi
 
 			# Make sure the removal succeeded.

--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -82,7 +82,7 @@ for query in sql/timeseries/$REPORTS.sql; do
 
 		if [ $? -eq 0 ]; then
 
-			echo "Updating this query: ${metric} for LENS: ${LENS}\n"
+			echo "Updating this query: ${metric} for LENS: ${LENS}"
 
 			# The file exists, so remove the requested date
 			current_contents=$(gsutil cat $gs_url)

--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -23,7 +23,7 @@ VERBOSE=0
 NO_CHANGES=0
 
 # Read the flags.
-while getopts ":vd:l:r:" opt; do
+while getopts ":nvd:l:r:" opt; do
 	case "${opt}" in
 		d)
 			YYYY_MM_DD=${OPTARG}
@@ -31,11 +31,11 @@ while getopts ":vd:l:r:" opt; do
 		v)
 			VERBOSE=1
 			;;
-		l)
-			LENS_ARG=${OPTARG}
-			;;
 		n)
 			NO_CHANGES=1
+			;;
+		l)
+			LENS_ARG=${OPTARG}
 			;;
 		r)
 			REPORTS=${OPTARG}
@@ -96,7 +96,7 @@ for query in sql/timeseries/$REPORTS.sql; do
 				echo "${current_contents}\n"
 			fi
 
-			new_contents=$(echo "$current_contents" | jq -c --indent 1 '.[] | select(.date!=env.YYYY_MM_DD)' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
+			new_contents=$(echo "$current_contents" | jq -c --indent 1 --arg date "${YYYY_MM_DD}" '.[] | select(.date!=$data)' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
 
 			if [ ${VERBOSE} -eq 1 ]; then
 				echo "New JSON:"

--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# Removes a particular date JSON from timeseries reports on Google Storage.
+#
+# Usage:
+#
+#   $ sql/delete_date_from_reports.sh -d YYYY_MM_DD
+#   $ sql/delete_date_from_reports.sh -d YYYY_MM_DD -l top1k
+#   $ sql/delete_date_from_reports.sh -d YYYY_MM_DD -l top1k -r "*crux*"
+#
+# Flags:
+#
+#   -l: Optional name of the report lens to generate, eg "top10k".
+#
+#   -r: Optional name of the report files to generate, eg "*crux*".
+#
+
+set -o pipefail
+
+FORCE=0
+LENS_ARG=""
+REPORTS="*"
+
+# Read the flags.
+while getopts ":d:l:r:" opt; do
+	case "${opt}" in
+		d)
+			YYYY_MM_DD=${OPTARG}
+			;;
+		l)
+			LENS_ARG=${OPTARG}
+			;;
+		r)
+			REPORTS=${OPTARG}
+			;;
+	esac
+done
+
+if [[ "${YYYY_MM_DD}" == "" ]]; then
+  echo "Usage $0 -d 2021_12_01"
+  exit 1
+fi
+
+echo "${YYYY_MM_DD}"
+
+# Run all timeseries queries.
+for query in sql/timeseries/$REPORTS.sql; do
+
+	if [[ ! -f $query ]]; then
+		echo "Nothing to do"
+		continue;
+	fi
+
+	# Extract the metric name from the file path.
+	metric=$(echo $(basename $query) | cut -d"." -f1)
+
+	if [[ "${LENS_ARG}" == "" ]]; then
+		LENSES=("")
+		echo "Deleting ${metric} report for base"
+	elif [[ "${LENS_ARG}" == "ALL" ]]; then
+		LENSES=("" $(ls sql/lens))
+		echo "Deleting ${metric} report for base and all lenses"
+	else
+		LENSES=("${LENS_ARG}")
+		echo "Deleting ${metric} report for one lens"
+	fi
+
+	for LENS in "${LENSES[@]}"
+	do
+
+		gs_lens_dir=""
+		if [[ $LENS != "" ]]; then
+			gs_lens_dir="$LENS/"
+		fi
+
+		current_contents=""
+		gs_url="gs://httparchive/reports/$gs_lens_dir${metric}.json"
+		gsutil ls $gs_url &> /dev/null
+
+		if [ $? -eq 0 ]; then
+
+			echo "Updating this query: ${sql}\n"
+
+			# The file exists, so remove the requested date
+			current_contents=$(gsutil cat $gs_url)
+			new_contents=$(echo "$current_contents" | jq -c --indent 1 '.[] | select(.date!="$YYY_MM_DD")' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
+
+			# Make sure the removal succeeded.
+			if [ $? -eq 0 ]; then
+
+				# Upload the response to Google Storage.
+				echo $new_contents \
+					| gsutil  -h "Content-Type:application/json" cp - $gs_url
+			else
+				echo $new_contents >&2
+			fi
+		fi
+	done
+done
+
+echo -e "Done"

--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -82,7 +82,7 @@ for query in sql/timeseries/$REPORTS.sql; do
 
 		if [ $? -eq 0 ]; then
 
-			echo "Updating this query: ${sql}\n"
+			echo "Updating this query: ${query}\n"
 
 			# The file exists, so remove the requested date
 			current_contents=$(gsutil cat $gs_url)
@@ -92,7 +92,7 @@ for query in sql/timeseries/$REPORTS.sql; do
 				echo "${current_contents}\n"
 			fi
 
-			new_contents=$(echo "$current_contents" | jq -c --indent 1 '.[] | select(.date!="$YYY_MM_DD")' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
+			new_contents=$(echo "$current_contents" | jq -c --indent 1 '.[] | select(.date!="$YYYY_MM_DD")' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
 
 			if [ ${VERBOSE} -eq 1 ]; then
 				echo "New JSON:"

--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -82,7 +82,7 @@ for query in sql/timeseries/$REPORTS.sql; do
 
 		if [ $? -eq 0 ]; then
 
-			echo "Updating this query: ${query}\n"
+			echo "Updating this query: ${metric} for LENS: ${LENS}\n"
 
 			# The file exists, so remove the requested date
 			current_contents=$(gsutil cat $gs_url)

--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -92,7 +92,7 @@ for query in sql/timeseries/$REPORTS.sql; do
 				echo "${current_contents}\n"
 			fi
 
-			new_contents=$(echo "$current_contents" | jq -c --indent 1 '.[] | select(.date!="$YYYY_MM_DD")' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
+			new_contents=$(echo "$current_contents" | jq -c --indent 1 '.[] | select(.date!=env.YYYY_MM_DD)' | tr -d '\n' | sed 's/^/[ /' | sed 's/}$/ } ]\n/' | sed 's/}{/ }, {/g')
 
 			if [ ${VERBOSE} -eq 1 ]; then
 				echo "New JSON:"

--- a/sql/delete_date_from_reports.sh
+++ b/sql/delete_date_from_reports.sh
@@ -20,6 +20,7 @@ set -o pipefail
 LENS_ARG=""
 REPORTS="*"
 VERBOSE=0
+NO_CHANGES=0
 
 # Read the flags.
 while getopts ":vd:l:r:" opt; do
@@ -32,6 +33,9 @@ while getopts ":vd:l:r:" opt; do
 			;;
 		l)
 			LENS_ARG=${OPTARG}
+			;;
+		n)
+			NO_CHANGES=1
 			;;
 		r)
 			REPORTS=${OPTARG}
@@ -100,7 +104,7 @@ for query in sql/timeseries/$REPORTS.sql; do
 			fi
 
 			# Make sure the removal succeeded.
-			if [ $? -eq 0 ]; then
+			if [ $? -eq 0 ] && [ ${NO_CHANGES} -eq 0 ]; then
 
 				# Upload the response to Google Storage.
 				echo "Uploading new file to Google Storage"


### PR DESCRIPTION
The 2021_12_01 run was a bit corrupted as discussed in https://github.com/HTTPArchive/httparchive.org/issues/518

Unfortunately the HTTP Archive reports had already run by the time this was discovered.

For the Histogram reports they can easily be rerun with the following command using the force flag (`-f`) to force them to ignore the existing file and just rerun:

```
nohup sql/generate_reports.sh -fh 2021_12_01 -l ALL &> nohup.out &
```

We could do the same for the timeseries and run it in force mode, but unfortunately they take a LOOOONG time to run from scratch as force mode for them means run for ALL dates, and not just force the last date. And with 7 lens's this will take forever. In fact I think there's a series risk they won't be done by the time January is processed and it'll get in a mess.

I've therefore knocked up a quite script to allow us to strip out a date from all the timeseries reports:

```
./sql/delete_date_from_reports.sh -d 2021_12_01 -l ALL
```

This will download each timeseries for each report, strip out the December data, and then re-upload it to GCP.

We can then rerun the report in incremental mode (or even wait for January run to do that as it'll be complete soon), which will be much quicker than rerunning from scratch:

```
nohup sql/generate_reports.sh -t -l ALL &> nohup.out &
```