### PR TITLE
Use 4 partitions for requests and response_bodies

### DIFF
--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -132,7 +132,7 @@ def get_response_bodies_a(har):
     logging.warning('Skipping response bodies payload: unable to get page URL (see preceding warning).')
     return
 
-  if hash_url(page_url) % 4 == 1:
+  if hash_url(page_url) % 4 != 1:
     return
 
   return get_response_bodies(har)
@@ -151,7 +151,7 @@ def get_response_bodies_b(har):
     logging.warning('Skipping response bodies payload: unable to get page URL (see preceding warning).')
     return
 
-  if hash_url(page_url) % 4 == 2:
+  if hash_url(page_url) % 4 != 2:
     return
 
   return get_response_bodies(har)
@@ -170,7 +170,7 @@ def get_response_bodies_c(har):
     logging.warning('Skipping response bodies payload: unable to get page URL (see preceding warning).')
     return
 
-  if hash_url(page_url) % 4 == 3:
+  if hash_url(page_url) % 4 != 3:
     return
 
   return get_response_bodies(har)
@@ -189,7 +189,7 @@ def get_response_bodies_d(har):
     logging.warning('Skipping response bodies payload: unable to get page URL (see preceding warning).')
     return
 
-  if hash_url(page_url) % 4 == 0:
+  if hash_url(page_url) % 4 != 0:
     return
 
   return get_response_bodies(har)

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -373,7 +373,8 @@ def run(argv=None):
 
     for i in range(NUM_PARTITIONS):
       (hars
-        | f'MapRequests{i}' >> beam.FlatMap(lambda har: partition_step(get_requests, har, i))
+        | f'MapRequests{i}' >> beam.FlatMap(
+          lambda i: lambda har: partition_step(get_requests, har, i)(i))
         | f'WriteRequests{i}' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'requests'),
           schema='page:STRING, url:STRING, payload:STRING',
@@ -381,7 +382,8 @@ def run(argv=None):
           create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
 
       (hars
-        | f'MapResponseBodies{i}' >> beam.FlatMap(lambda har: partition_step(get_response_bodies, har, i))
+        | f'MapResponseBodies{i}' >> beam.FlatMap(
+          lambda i: lambda har: partition_step(get_response_bodies, har, i)(i))
         | f'WriteResponseBodies{i}' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'response_bodies'),
           schema='page:STRING, url:STRING, body:STRING, truncated:BOOLEAN',

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -374,7 +374,7 @@ def run(argv=None):
     for i in range(NUM_PARTITIONS):
       (hars
         | f'MapRequests{i}' >> beam.FlatMap(
-          lambda i: lambda har: partition_step(get_requests, har, i)(i))
+          (lambda i: lambda har: partition_step(get_requests, har, i))(i))
         | f'WriteRequests{i}' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'requests'),
           schema='page:STRING, url:STRING, payload:STRING',
@@ -383,7 +383,7 @@ def run(argv=None):
 
       (hars
         | f'MapResponseBodies{i}' >> beam.FlatMap(
-          lambda i: lambda har: partition_step(get_response_bodies, har, i)(i))
+          (lambda i: lambda har: partition_step(get_response_bodies, har, i))(i))
         | f'WriteResponseBodies{i}' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'response_bodies'),
           schema='page:STRING, url:STRING, body:STRING, truncated:BOOLEAN',

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -354,7 +354,7 @@ def run(argv=None):
         | f'WritePages{i}' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'pages'),
           schema='url:STRING, payload:STRING',
-          write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+          write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND,
           create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
 
       (hars
@@ -363,16 +363,16 @@ def run(argv=None):
         | f'WriteTechnologies{i}' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'technologies'),
           schema='url:STRING, category:STRING, app:STRING, info:STRING',
-          write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+          write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND,
           create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
 
       (hars
-        | f'MapLighthouseReport{i}s' >> beam.FlatMap(
+        | f'MapLighthouseReports{i}' >> beam.FlatMap(
           (lambda i: lambda har: partition_step(get_lighthouse_reports, har, i))(i))
         | f'WriteLighthouseReports{i}' >> beam.io.WriteToBigQuery(
           get_bigquery_uri(known_args.input, 'lighthouse'),
           schema='url:STRING, report:STRING',
-          write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
+          write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND,
           create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED))
       (hars
         | f'MapRequests{i}' >> beam.FlatMap(

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -69,7 +69,10 @@ def get_page_url(har):
 def partition_step(fn, har, index):
   """Partitions functions across multiple concurrent steps."""
 
+  logging.info(f'partitioning step {fn}, index {index}')
+
   if not har:
+    logging.warning('Unable to partition step, null HAR.')
     return
 
   page_url = get_page_url(har)
@@ -78,7 +81,9 @@ def partition_step(fn, har, index):
     logging.warning('Skipping HAR: unable to get page URL (see preceding warning).')
     return
 
-  if hash_url(page_url) % NUM_PARTITIONS != index:
+  hash = hash_url(page_url)
+  if hash % NUM_PARTITIONS != index:
+    logging.info(f'Skipping partition. {hash} % {NUM_PARTITIONS} != {index}')
     return
   
   return fn(har)

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -33,7 +33,7 @@ def get_page(har):
   if metadata:
     # The page URL from metadata is more accurate.
     # See https://github.com/HTTPArchive/data-pipeline/issues/48
-    url = metadata.get('tested_url')
+    url = metadata.get('tested_url', url)
 
   try:
     payload_json = to_json(page)


### PR DESCRIPTION
Fixes https://github.com/HTTPArchive/data-pipeline/issues/59

We've been bisecting the response bodies pipeline so that the each of two write jobs are independently less than the 15 TB limit, even though the total table size may be 15+ TB.

Now that we have secondary pages, we need to increase the number of partitions by 2x in order to stay under the limits.

Tested on the `gs://httparchive/test-May_24_2022` subset of 2 HARs. 

<img width="1992" alt="image" src="https://user-images.githubusercontent.com/1120896/170140531-6f92803c-cf71-4a00-a787-5a509cdfa094.png">
