### PR TITLE
Ignore 2022_05_12 tables from report generation

### DIFF
--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -252,7 +252,7 @@ else
             elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
               date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) > \"$max_date\""
               # Skip 2022_05_12 tables
-              date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2021_05_12\""
+              date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2022_05_12\""
               if [[ -n "$YYYY_MM_DD" ]]; then
                 # If a date is given, then only run up until then (in case next month is mid run as don't wanna get just desktop data)
                 date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
@@ -276,7 +276,7 @@ else
             # If a date is given, then only run up until then (in case next month is mid run as don't wanna get just desktop data)
             date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
             # Skip 2022_05_12 tables
-            date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2021_05_12\""
+            date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2022_05_12\""
           fi
 
           echo -e "Force Mode=${FORCE}. Generating $gs_lens_dir$metric timeseries from start until ${YYYY_MM_DD}."
@@ -290,7 +290,7 @@ else
         elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
           date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
           # Skip 2022_05_12 tables
-          date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2021_05_12\""
+          date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2022_05_12\""
         fi
 
         echo -e "Timeseries does not exist. Generating $gs_lens_dir$metric timeseries from start until ${YYYY_MM_DD}"

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -251,6 +251,8 @@ else
               fi
             elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
               date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) > \"$max_date\""
+              # Skip 2022_05_12 tables
+              date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2021_05_12\""
               if [[ -n "$YYYY_MM_DD" ]]; then
                 # If a date is given, then only run up until then (in case next month is mid run as don't wanna get just desktop data)
                 date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
@@ -273,6 +275,8 @@ else
           elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
             # If a date is given, then only run up until then (in case next month is mid run as don't wanna get just desktop data)
             date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
+            # Skip 2022_05_12 tables
+            date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2021_05_12\""
           fi
 
           echo -e "Force Mode=${FORCE}. Generating $gs_lens_dir$metric timeseries from start until ${YYYY_MM_DD}."
@@ -285,6 +289,8 @@ else
           date_join="yyyymmdd <= CAST(REPLACE(\"$YYYY_MM_DD\",\"_\",\"-\") AS DATE)"
         elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
           date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
+          # Skip 2022_05_12 tables
+          date_join="${date_join} AND SUBSTR(_TABLE_SUFFIX, 0, 10) != \"2021_05_12\""
         fi
 
         echo -e "Timeseries does not exist. Generating $gs_lens_dir$metric timeseries from start until ${YYYY_MM_DD}"

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -245,6 +245,8 @@ else
               fi
             elif [[ $(grep "httparchive.blink_features.usage" $query) && $LENS != "" ]]; then # blink needs a special join, different for lenses
               date_join="yyyymmdd > CAST(REPLACE(\"$max_date\",\"_\",\"-\") AS DATE)"
+               # Skip 2022_05_12 tables
+              date_join="${date_join} AND yyyymmdd != \"2022-05-12\""
               if [[ -n "$YYYY_MM_DD" ]]; then
                 # If a date is given, then only run up until then (in case next month is mid run as don't wanna get just desktop data)
                 date_join="${date_join} AND yyyymmdd <= CAST(REPLACE(\"$YYYY_MM_DD\",\"_\",\"-\") AS DATE)"
@@ -272,6 +274,8 @@ else
             date_join="yyyymmdd <= REPLACE(\"$YYYY_MM_DD\",\"_\",\"\")"
           elif [[ $(grep "httparchive.blink_features.usage" $query) && $LENS != "" ]]; then # blink needs a special join, different for lenses
             date_join="yyyymmdd <= CAST(REPLACE(\"$YYYY_MM_DD\",\"_\",\"-\") AS DATE)"
+            # Skip 2022_05_12 tables
+            date_join="${date_join} AND yyyymmdd != \"2022-05-12\""
           elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
             # If a date is given, then only run up until then (in case next month is mid run as don't wanna get just desktop data)
             date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
@@ -287,6 +291,8 @@ else
           date_join="yyyymmdd <= REPLACE(\"$YYYY_MM_DD\",\"_\",\"\")"
         elif [[ $(grep "httparchive.blink_features.usage" $query) && $LENS != "" ]]; then # blink needs a special join, different for lenses
           date_join="yyyymmdd <= CAST(REPLACE(\"$YYYY_MM_DD\",\"_\",\"-\") AS DATE)"
+          # Skip 2022_05_12 tables
+          date_join="${date_join} AND yyyymmdd != \"2022-05-12\""
         elif [[ $metric != crux* ]]; then # CrUX is quick and join is more compilicated so just do a full run of that
           date_join="SUBSTR(_TABLE_SUFFIX, 0, 10) <= \"$YYYY_MM_DD\""
           # Skip 2022_05_12 tables


### PR DESCRIPTION
2022_05_12 is a rerun, containing both home pages and secondary pages. We'll eventually clean it up but, for now, want to specifically exclude it from reports so they charts on https://httparchive.org/reports don't get thrown off.