### PR TITLE
Ignore secondary pages in non-summary pipeline

### DIFF
--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -75,6 +75,12 @@ def partition_step(fn, har, index):
     logging.warning('Unable to partition step, null HAR.')
     return
 
+  page = har.get('log').get('pages')[0]
+  metadata = page.get('_metadata')
+  if metadata.get('crawl_depth') and metadata.get('crawl_depth') != '1':
+    # Only home pages have a crawl depth of 1.
+    return
+
   page_url = get_page_url(har)
 
   if not page_url:

--- a/dataflow/python/bigquery_import.py
+++ b/dataflow/python/bigquery_import.py
@@ -77,8 +77,8 @@ def partition_step(fn, har, index):
 
   page = har.get('log').get('pages')[0]
   metadata = page.get('_metadata')
-  if metadata.get('crawl_depth') and metadata.get('crawl_depth') != '1':
-    # Only home pages have a crawl depth of 1.
+  if metadata.get('crawl_depth') and metadata.get('crawl_depth') != '0':
+    # Only home pages have a crawl depth of 0.
     return
 
   page_url = get_page_url(har)


### PR DESCRIPTION
Only home page data should be written to the YYYY_MM_DD tables (ie `pages.2022_06_01_desktop`). The new pipeline being developed in https://github.com/HTTPArchive/data-pipeline/pull/75 will handle writing home and secondary page data to the new `all` dataset.