### PR TITLE
Update crontab to latest

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,7 +1,14 @@
-0 15 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_csv.sh `date +\%b_1_\%Y`'  >> /var/log/HAimport.log 2>&1
-0  8 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_csv.sh mobile_`date +\%b_1_\%Y`'  >> /var/log/HAimport.log 2>&1
+#0 15 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_csv.sh `date +\%b_1_\%Y`'  >> /var/log/HAimport.log 2>&1
+#0  8 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_csv.sh mobile_`date +\%b_1_\%Y`'  >> /var/log/HAimport.log 2>&1
 
-0 10 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_har.sh chrome' >> /var/log/HA-import-har-chrome.log 2>&1
-0 11 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_har.sh android' >> /var/log/HA-import-har-android.log 2>&1
+#0 10 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_har.sh chrome' >> /var/log/HA-import-har-chrome.log 2>&1
+#0 11 * * * /bin/bash -l -c 'cd /home/igrigorik/code && ./sync_har.sh android' >> /var/log/HA-import-har-android.log 2>&1
 
-0 7 15 * * /bin/bash -l -c 'cd /home/igrigorik/code && sql/generate_reports.sh -th `date -d "-1 month" "+\%Y_\%m_01"` -r "*crux*" -l ALL' >> /var/log/crux_reruns.log 2>&1
+# Attempt to run the reports everyday
+0  8 * * * /bin/bash -l -c 'cd /home/igrigorik/code && sql/generate_reports.sh -th `date "+\%Y_\%m_01"` -l ALL' >> /var/log/generate_reports.log 2>&1
+
+# Run the reports on the 2nd to pick up blink table updates
+0  7 2 * * /bin/bash -l -c 'cd /home/igrigorik/code && sql/generate_reports.sh -th `date -d "-1 month" "+\%Y_\%m_01"` -l ALL' >> /var/log/generate_last_months_reports.log 2>&1
+
+# Run the CrUX reports on 15th
+0  7 15 * * /bin/bash -l -c 'cd /home/igrigorik/code && sql/generate_reports.sh -th `date -d "-1 month" "+\%Y_\%m_01"` -r "*crux*" -l ALL' >> /var/log/crux_reruns.log 2>&1


### PR DESCRIPTION
We've commented out the old pipeline jobs as now from https://github.com/HTTPArchive/data-pipeline

I've added a new entry to attempt to run the reports everyday of the month.
- This will exit early if the reports do not exist.
- It WILL however run each day AFTER the reports are run, but not find any reports to run. a Bit of a waste, but not sure it's worth catering for that as we hope to migrate off of this in https://github.com/HTTPArchive/data-pipeline/issues/177 ?

I've also added a line to run the reports on the 2nd. This is because the blink tables are updated on the 1st of the month by a BigQuery scheduled task. Traditionally we've just let them be picked up in next months run, but we can get the data sooner for those reports with this new entry. Will make a not in https://github.com/HTTPArchive/data-pipeline/issues/177 to see if we can tackle at same time.

And then there is the CrUX reports (which are not available until the 2nd Tuesday of the month - of which the 15th, when this cron is run, is guaranteed to be after that).