### PR TITLE
Indentation changes in prep for SQLFluff v2

### DIFF
--- a/sql/.sqlfluff
+++ b/sql/.sqlfluff
@@ -112,7 +112,7 @@ unwrap_wrapped_queries = True
 apply_dbt_builtins = True
 
 [sqlfluff:templater:jinja:context]
-BLINK_DATE_JOIN=
+BLINK_DATE_JOIN="AND 1=2"
 
 [sqlfluff:templater:jinja:macros]
 # Macros provided as builtins for dbt projects

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -316,10 +316,10 @@ else
             # For blink features for lenses we have a BLINK_DATE_JOIN variable to replace
             if [[ -z "${date_join}" ]]; then
               sql=$(sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
-              | sed -e "s/ {{ BLINK_DATE_JOIN }}//g")
+              | sed -e "s/   {{ BLINK_DATE_JOIN }}//g")
             else
               sql=$( sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
-                | sed -e "s/{{ BLINK_DATE_JOIN }}/AND $date_join/g")
+                | sed -e "s/  {{ BLINK_DATE_JOIN }}/AND $date_join/g")
             fi
           else
             echo "blink_features.usage queries not supported for this lens so skipping lens"

--- a/sql/generate_reports.sh
+++ b/sql/generate_reports.sh
@@ -316,10 +316,10 @@ else
             # For blink features for lenses we have a BLINK_DATE_JOIN variable to replace
             if [[ -z "${date_join}" ]]; then
               sql=$(sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
-              | sed -e "s/   {{ BLINK_DATE_JOIN }}//g")
+              | sed -e "s/ {{ BLINK_DATE_JOIN }}//g")
             else
               sql=$( sed -e "s/\`httparchive.blink_features.usage\`/($lens_join)/" $query \
-                | sed -e "s/  {{ BLINK_DATE_JOIN }}/AND $date_join/g")
+                | sed -e "s/{{ BLINK_DATE_JOIN }}/AND $date_join/g")
             fi
           else
             echo "blink_features.usage queries not supported for this lens so skipping lens"

--- a/sql/histograms/bootupJs.sql
+++ b/sql/histograms/bootupJs.sql
@@ -17,7 +17,9 @@ FROM (
       bin,
       client
     HAVING
-      bin IS NOT NULL))
+      bin IS NOT NULL
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesCss.sql
+++ b/sql/histograms/bytesCss.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesFont.sql
+++ b/sql/histograms/bytesFont.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesHtml.sql
+++ b/sql/histograms/bytesHtml.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesImg.sql
+++ b/sql/histograms/bytesImg.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesJs.sql
+++ b/sql/histograms/bytesJs.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesOther.sql
+++ b/sql/histograms/bytesOther.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesTotal.sql
+++ b/sql/histograms/bytesTotal.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/bytesVideo.sql
+++ b/sql/histograms/bytesVideo.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/compileJs.sql
+++ b/sql/histograms/compileJs.sql
@@ -18,7 +18,9 @@ FROM (
       client
     HAVING
       bin IS NOT NULL AND
-      bin >= 0))
+      bin >= 0
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxCls.sql
+++ b/sql/histograms/cruxCls.sql
@@ -35,12 +35,15 @@ FROM (
         form_factor,
         spreadBins(layout_instability.cumulative_layout_shift.histogram.bin) AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxDcl.sql
+++ b/sql/histograms/cruxDcl.sql
@@ -35,12 +35,15 @@ FROM (
         form_factor,
         spreadBins(dom_content_loaded.histogram.bin) AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxFcp.sql
+++ b/sql/histograms/cruxFcp.sql
@@ -35,12 +35,15 @@ FROM (
         form_factor,
         spreadBins(first_contentful_paint.histogram.bin) AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxFid.sql
+++ b/sql/histograms/cruxFid.sql
@@ -35,12 +35,15 @@ FROM (
         form_factor,
         spreadBins(first_input.delay.histogram.bin) AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxFp.sql
+++ b/sql/histograms/cruxFp.sql
@@ -35,12 +35,15 @@ FROM (
         form_factor,
         spreadBins(first_paint.histogram.bin) AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxInp.sql
+++ b/sql/histograms/cruxInp.sql
@@ -16,12 +16,15 @@ FROM (
         form_factor,
         experimental.interaction_to_next_paint.histogram.bin AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxLcp.sql
+++ b/sql/histograms/cruxLcp.sql
@@ -35,12 +35,15 @@ FROM (
         form_factor,
         spreadBins(largest_contentful_paint.histogram.bin) AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxOl.sql
+++ b/sql/histograms/cruxOl.sql
@@ -35,12 +35,15 @@ FROM (
         form_factor,
         spreadBins(onload.histogram.bin) AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/cruxTtfb.sql
+++ b/sql/histograms/cruxTtfb.sql
@@ -16,12 +16,15 @@ FROM (
         form_factor,
         experimental.time_to_first_byte.histogram.bin AS bins
       FROM
-        `chrome-ux-report.all.${YYYYMM}`)
+        `chrome-ux-report.all.${YYYYMM}`
+    )
     CROSS JOIN
       UNNEST(bins) AS bin
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/dcl.sql
+++ b/sql/histograms/dcl.sql
@@ -17,7 +17,9 @@ FROM (
       onContentLoaded > 0
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/evalJs.sql
+++ b/sql/histograms/evalJs.sql
@@ -18,7 +18,9 @@ FROM (
       client
     HAVING
       bin IS NOT NULL AND
-      bin >= 0))
+      bin >= 0
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/fcp.sql
+++ b/sql/histograms/fcp.sql
@@ -18,7 +18,9 @@ FROM (
       client
     HAVING
       bin IS NOT NULL AND
-      bin >= 0))
+      bin >= 0
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/gzipSavings.sql
+++ b/sql/histograms/gzipSavings.sql
@@ -17,7 +17,9 @@ FROM (
       bin,
       client
     HAVING
-      bin IS NOT NULL))
+      bin IS NOT NULL
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/imgSavings.sql
+++ b/sql/histograms/imgSavings.sql
@@ -17,7 +17,9 @@ FROM (
       bin,
       client
     HAVING
-      bin IS NOT NULL))
+      bin IS NOT NULL
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/offscreenImages.sql
+++ b/sql/histograms/offscreenImages.sql
@@ -17,7 +17,9 @@ FROM (
       bin,
       client
     HAVING
-      bin IS NOT NULL))
+      bin IS NOT NULL
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/ol.sql
+++ b/sql/histograms/ol.sql
@@ -17,7 +17,9 @@ FROM (
       onLoad > 0
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/optimizedImages.sql
+++ b/sql/histograms/optimizedImages.sql
@@ -17,7 +17,9 @@ FROM (
       bin,
       client
     HAVING
-      bin IS NOT NULL))
+      bin IS NOT NULL
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqCss.sql
+++ b/sql/histograms/reqCss.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqFont.sql
+++ b/sql/histograms/reqFont.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqHtml.sql
+++ b/sql/histograms/reqHtml.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqImg.sql
+++ b/sql/histograms/reqImg.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqJs.sql
+++ b/sql/histograms/reqJs.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqOther.sql
+++ b/sql/histograms/reqOther.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqTotal.sql
+++ b/sql/histograms/reqTotal.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/reqVideo.sql
+++ b/sql/histograms/reqVideo.sql
@@ -15,7 +15,9 @@ FROM (
       `httparchive.summary_pages.${YYYY_MM_DD}_*`
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/speedIndex.sql
+++ b/sql/histograms/speedIndex.sql
@@ -17,7 +17,9 @@ FROM (
       bin,
       client
     HAVING
-      bin IS NOT NULL))
+      bin IS NOT NULL
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/tcp.sql
+++ b/sql/histograms/tcp.sql
@@ -17,7 +17,9 @@ FROM (
       _connections > 0
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/ttci.sql
+++ b/sql/histograms/ttci.sql
@@ -17,7 +17,9 @@ FROM (
       bin,
       client
     HAVING
-      bin IS NOT NULL))
+      bin IS NOT NULL
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/histograms/vulnJs.sql
+++ b/sql/histograms/vulnJs.sql
@@ -31,7 +31,9 @@ FROM (
       report IS NOT NULL
     GROUP BY
       bin,
-      client))
+      client
+  )
+)
 ORDER BY
   bin,
   client

--- a/sql/lens/drupal/blink_timeseries.sql
+++ b/sql/lens/drupal/blink_timeseries.sql
@@ -44,14 +44,14 @@ JOIN (
     )
   ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || '_' || client)
   WHERE 1 = 1
-{{ BLINK_DATE_JOIN }}
+    {{ BLINK_DATE_JOIN }}
   GROUP BY
     yyyymmdd,
     client
-  )
+)
 USING (yyyymmdd, client)
 WHERE 1 = 1
-{{ BLINK_DATE_JOIN }}
+  {{ BLINK_DATE_JOIN }}
 GROUP BY
   yyyymmdd,
   client,

--- a/sql/lens/magento/blink_timeseries.sql
+++ b/sql/lens/magento/blink_timeseries.sql
@@ -44,14 +44,14 @@ JOIN (
     )
   ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || '_' || client)
   WHERE 1 = 1
-{{ BLINK_DATE_JOIN }}
+    {{ BLINK_DATE_JOIN }}
   GROUP BY
     yyyymmdd,
     client
-  )
+)
 USING (yyyymmdd, client)
 WHERE 1 = 1
-{{ BLINK_DATE_JOIN }}
+  {{ BLINK_DATE_JOIN }}
 GROUP BY
   yyyymmdd,
   client,

--- a/sql/lens/top100k/blink_timeseries.sql
+++ b/sql/lens/top100k/blink_timeseries.sql
@@ -19,7 +19,7 @@ JOIN
     WHERE
       rank <= 100000 AND
       yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+      {{ BLINK_DATE_JOIN }}
     GROUP BY
       yyyymmdd,
       client
@@ -28,7 +28,7 @@ USING (yyyymmdd, client)
 WHERE
   rank <= 100000 AND
   yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+  {{ BLINK_DATE_JOIN }}
 GROUP BY
   yyyymmdd,
   client,

--- a/sql/lens/top10k/blink_timeseries.sql
+++ b/sql/lens/top10k/blink_timeseries.sql
@@ -18,16 +18,16 @@ JOIN (
   WHERE
     rank <= 10000 AND
     yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+    {{ BLINK_DATE_JOIN }}
   GROUP BY
     yyyymmdd,
     client
-  )
+)
 USING (yyyymmdd, client)
 WHERE
   rank <= 10000 AND
   yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+  {{ BLINK_DATE_JOIN }}
 GROUP BY
   yyyymmdd,
   client,

--- a/sql/lens/top1k/blink_timeseries.sql
+++ b/sql/lens/top1k/blink_timeseries.sql
@@ -18,16 +18,16 @@ JOIN (
   WHERE
     rank <= 1000 AND
     yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+    {{ BLINK_DATE_JOIN }}
   GROUP BY
     yyyymmdd,
     client
-  )
+)
 USING (yyyymmdd, client)
 WHERE
   rank <= 1000 AND
   yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+  {{ BLINK_DATE_JOIN }}
 GROUP BY
   yyyymmdd,
   client,

--- a/sql/lens/top1m/blink_timeseries.sql
+++ b/sql/lens/top1m/blink_timeseries.sql
@@ -18,16 +18,16 @@ JOIN (
   WHERE
     rank <= 1000000 AND
     yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+    {{ BLINK_DATE_JOIN }}
   GROUP BY
     yyyymmdd,
     client
-  )
+)
 USING (yyyymmdd, client)
 WHERE
   rank <= 1000000 AND
   yyyymmdd >= '2021-05-01'
-{{ BLINK_DATE_JOIN }}
+  {{ BLINK_DATE_JOIN }}
 GROUP BY
   yyyymmdd,
   client,

--- a/sql/lens/wordpress/blink_timeseries.sql
+++ b/sql/lens/wordpress/blink_timeseries.sql
@@ -44,14 +44,14 @@ JOIN (
     )
   ON (url = tech_url AND _TABLE_SUFFIX = FORMAT_DATE('%Y_%m_%d', yyyymmdd) || '_' || client)
   WHERE 1 = 1
-{{ BLINK_DATE_JOIN }}
+    {{ BLINK_DATE_JOIN }}
   GROUP BY
     yyyymmdd,
     client
-  )
+)
 USING (yyyymmdd, client)
 WHERE 1 = 1
-{{ BLINK_DATE_JOIN }}
+  {{ BLINK_DATE_JOIN }}
 GROUP BY
   yyyymmdd,
   client,

--- a/sql/timeseries/bootupJs.sql
+++ b/sql/timeseries/bootupJs.sql
@@ -14,7 +14,7 @@ FROM (
     CAST(IFNULL(
       JSON_EXTRACT(report, '$.audits.bootup-time.numericValue'),
       JSON_EXTRACT(report, '$.audits.bootup-time.rawValue')
-      ) AS FLOAT64) / 1000 AS value
+    ) AS FLOAT64) / 1000 AS value
   FROM
     `httparchive.lighthouse.*`
 )

--- a/sql/timeseries/cruxFastDcl.sql
+++ b/sql/timeseries/cruxFastDcl.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Fast Dopm Content Loaded by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxFastFcp.sql
+++ b/sql/timeseries/cruxFastFcp.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Fast FCP by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxFastFid.sql
+++ b/sql/timeseries/cruxFastFid.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Fast FID by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxFastFp.sql
+++ b/sql/timeseries/cruxFastFp.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Fast First Paint by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxFastInp.sql
+++ b/sql/timeseries/cruxFastInp.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Small CLS by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxFastLcp.sql
+++ b/sql/timeseries/cruxFastLcp.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Fast LCP by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxFastOl.sql
+++ b/sql/timeseries/cruxFastOl.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Fast Onload by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxFastTtfb.sql
+++ b/sql/timeseries/cruxFastTtfb.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Small CLS by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   SAFE_DIVIDE(good, (good + needs_improvement + poor)) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxLargeCls.sql
+++ b/sql/timeseries/cruxLargeCls.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Large CLS by device
 
-CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_POOR(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   poor / (good + needs_improvement + poor) >= 0.25
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxPassesCWV.sql
+++ b/sql/timeseries/cruxPassesCWV.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Passes Core Web Vitals by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 
@@ -15,10 +15,11 @@ SELECT
   IF(device = 'desktop', 'desktop', 'mobile') AS client,
   SAFE_DIVIDE(
     COUNT(DISTINCT IF(
-        /* FID can be null and is not mandatory for CWV */
-        (p75_fid IS NULL OR IS_GOOD(fast_fid, avg_fid, slow_fid)) AND
-        IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
-        IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL)),
+      /* FID can be null and is not mandatory for CWV */
+      (p75_fid IS NULL OR IS_GOOD(fast_fid, avg_fid, slow_fid)) AND
+      IS_GOOD(fast_lcp, avg_lcp, slow_lcp) AND
+      IS_GOOD(small_cls, medium_cls, large_cls), origin, NULL
+    )),
     COUNT(DISTINCT origin)
   ) * 100 AS percent
 FROM

--- a/sql/timeseries/cruxSlowFcp.sql
+++ b/sql/timeseries/cruxSlowFcp.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Slow FCP by device
 
-CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_POOR(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   poor / (good + needs_improvement + poor) >= 0.25
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxSlowFid.sql
+++ b/sql/timeseries/cruxSlowFid.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Slow FID by device
 
-CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_POOR(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   poor / (good + needs_improvement + poor) >= 0.25
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxSlowInp.sql
+++ b/sql/timeseries/cruxSlowInp.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Large CLS by device
 
-CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_POOR(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   poor / (good + needs_improvement + poor) >= 0.25
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxSlowLcp.sql
+++ b/sql/timeseries/cruxSlowLcp.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Slow LCP by device
 
-CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_POOR(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   poor / (good + needs_improvement + poor) >= 0.25
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxSlowTtfb.sql
+++ b/sql/timeseries/cruxSlowTtfb.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Large CLS by device
 
-CREATE TEMP FUNCTION IS_POOR (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_POOR(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   SAFE_DIVIDE(poor, (good + needs_improvement + poor)) >= 0.25
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/cruxSmallCls.sql
+++ b/sql/timeseries/cruxSmallCls.sql
@@ -1,11 +1,11 @@
 #standardSQL
 # Small CLS by device
 
-CREATE TEMP FUNCTION IS_GOOD (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good / (good + needs_improvement + poor) >= 0.75
 );
 
-CREATE TEMP FUNCTION IS_NON_ZERO (good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
   good + needs_improvement + poor > 0
 );
 

--- a/sql/timeseries/h3.sql
+++ b/sql/timeseries/h3.sql
@@ -21,7 +21,10 @@ SELECT
         reqHttpVersion IN ('HTTP/3', 'h3', 'h3-29') OR
         REGEXP_EXTRACT(REGEXP_EXTRACT(respOtherHeaders, r'alt-svc = (.*)'), r'(.*?)(?:, [^ ]* = .*)?$') LIKE '%h3=%' OR
         REGEXP_EXTRACT(REGEXP_EXTRACT(respOtherHeaders, r'alt-svc = (.*)'), r'(.*?)(?:, [^ ]* = .*)?$') LIKE '%h3-29=%',
-        1, 0)) * 100 / COUNT(0), 2) AS percent
+        1, 0
+      )
+    ) * 100 / COUNT(0), 2
+  ) AS percent
 FROM
   `httparchive.summary_requests.*`
 WHERE

--- a/sql/timeseries/swControlledPages.sql
+++ b/sql/timeseries/swControlledPages.sql
@@ -3,10 +3,15 @@ SELECT
   SUBSTR(_TABLE_SUFFIX, 0, 10) AS date,
   UNIX_DATE(CAST(REPLACE(SUBSTR(_TABLE_SUFFIX, 0, 10), '_', '-') AS DATE)) * 1000 * 60 * 60 * 24 AS timestamp,
   IF(ENDS_WITH(_TABLE_SUFFIX, 'desktop'), 'desktop', 'mobile') AS client,
-  ROUND(SUM(IF(IFNULL(
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ServiceWorkerControlledPage'),
-    JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.990'))
-        IS NOT NULL, 1, 0)) * 100 / COUNT(0), 2) AS percent
+  ROUND(
+    SUM(
+      IF(IFNULL(
+        JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.ServiceWorkerControlledPage'),
+        JSON_EXTRACT(payload, '$._blinkFeatureFirstUsed.Features.990')
+      ) IS NOT NULL, 1, 0)) * 100 / COUNT(0
+    ),
+    2
+  ) AS percent
 FROM
   `httparchive.pages.*`
 GROUP BY

--- a/sql/timeseries/ttci.sql
+++ b/sql/timeseries/ttci.sql
@@ -17,7 +17,7 @@ FROM (
         JSON_EXTRACT(report, '$.audits.interactive.rawValue'),
         JSON_EXTRACT(report, '$.audits.consistently-interactive.rawValue')
       )
-      ) AS FLOAT64) / 1000 AS value
+    ) AS FLOAT64) / 1000 AS value
   FROM
     `httparchive.lighthouse.*`
 )


### PR DESCRIPTION
SQLFluff v2 has just been released and includes some indentation changes (amongst other things). The changes look good to me, and also work in SQLFluff v1 so this PR makes them in preparation of v2 being released to the GitHub Super Liner in future (note there will be some config changes required then).